### PR TITLE
[bugfix] support sandboxId in session authentication

### DIFF
--- a/src/eyepop-render-2d/package.json
+++ b/src/eyepop-render-2d/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eyepop.ai/eyepop-render-2d",
-  "version": "0.18.5",
+  "version": "0.18.6",
   "description": "The Node.js / Typescript library for 2d rendering of EyePop.ai's inference API",
   "keywords": [
     "AI",

--- a/src/eyepop/package.json
+++ b/src/eyepop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eyepop.ai/eyepop",
-  "version": "0.18.5",
+  "version": "0.18.6",
   "description": "The official Node.js / Typescript library for EyePop.ai's inference API",
   "keywords": [
     "AI",

--- a/src/eyepop/types.ts
+++ b/src/eyepop/types.ts
@@ -8,6 +8,7 @@ export interface Session {
 export interface SessionPlus extends Session {
     readonly baseUrl: string;
     readonly pipelineId: string;
+    readonly sandboxId: string | undefined;
 }
 
 export enum EndpointState {


### PR DESCRIPTION
For session authentication, support a sandboxId that has to be passed into pipeline restarts. Managing sandboxes is a server side feature only, but sessions created on the server side should be fully functional in the browser too.