### PR TITLE
[session] Support permanent session via env var EYEPOP_SESSION_UUID or WorkerOptions.sessionUuid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,81 @@
-# EyePop.ai JavaScript SDK
+# EyePop.ai Node SDK
 
-The EyePop.ai JavaScript SDK provides TypeScript and JavaScript clients for EyePop worker sessions, inference results, and 2D result rendering.
+The EyePop.ai Node SDK lets Node.js applications process images and videos with EyePop worker sessions.
 
-## Packages
+## Install
+
+```shell
+npm install @eyepop.ai/eyepop
+```
+
+The SDK is tested with Node 20 LTS and newer.
+
+## Configure
+
+Set your EyePop API key in the server environment:
+
+```shell
+export EYEPOP_API_KEY=<your_api_key>
+```
+
+For a provisioned persistent worker session, also set the session UUID:
+
+```shell
+export EYEPOP_SESSION_UUID=<your_session_uuid>
+```
+
+API keys are secrets. Do not put `EYEPOP_API_KEY` in browser bundles, mobile app bundles, or public repositories.
+
+## Quickstart
+
+Create `quickstart.mjs`:
+
+```javascript
+import { EyePop } from '@eyepop.ai/eyepop'
+
+const endpoint = await EyePop.workerEndpoint().connect()
+
+try {
+    const results = await endpoint.process({
+        source: { path: 'sample.mp4' },
+    })
+
+    for await (const result of results) {
+        console.log(result)
+    }
+} finally {
+    await endpoint.disconnect()
+}
+```
+
+Run it:
+
+```shell
+node quickstart.mjs
+```
+
+When `EYEPOP_SESSION_UUID` is set, `EyePop.workerEndpoint()` connects to that persistent session. Otherwise it creates a transient worker session.
+
+## Configure a Pop
+
+Transient sessions can be configured in code before processing media:
+
+```javascript
+await endpoint.changePop({
+    components: [
+        {
+            type: 'inference',
+            model: 'eyepop.person:latest',
+            categoryName: 'person',
+        },
+    ],
+})
+```
+
+Persistent sessions are usually preconfigured. Process media directly unless your deployment is intended to accept runtime Pop changes.
+
+## Module Docs
 
 - [@eyepop.ai/eyepop](src/eyepop/README.md) - Node and browser SDK for worker sessions.
 - [@eyepop.ai/eyepop-render-2d](src/eyepop-render-2d/README.md) - Canvas rendering helpers for predictions.
 - [@eyepop.ai/react-native-eyepop](src/react-native-eyepop/README.md) - React Native SDK package.
-
-## Authentication Model
-
-Use `EYEPOP_API_KEY` only in trusted server-side environments. Browser and mobile applications should request an EyePop session from your backend and connect with `auth: { session }`.
-
-Persistent worker deployments can be selected with `EYEPOP_SESSION_UUID` in the trusted server environment.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
-# EyePop.ai Node SDK
+# EyePop.ai JavaScript SDK
 
-The EyePop.ai Node SDK provides convenient access to the EyePop.ai's inference API from applications written in the
-TypeScript or JavaScript language. The SDK is published in individual sub-modules:
+The EyePop.ai JavaScript SDK provides TypeScript and JavaScript clients for EyePop worker sessions, inference results, and 2D result rendering.
 
--   [@eyepop.ai/eyepop](src/eyepop/README.md)
--   [@eyepop.ai/eyepop-render-2d](src/eyepop-render-2d/README.md)
+## Packages
+
+- [@eyepop.ai/eyepop](src/eyepop/README.md) - Node and browser SDK for worker sessions.
+- [@eyepop.ai/eyepop-render-2d](src/eyepop-render-2d/README.md) - Canvas rendering helpers for predictions.
+- [@eyepop.ai/react-native-eyepop](src/react-native-eyepop/README.md) - React Native SDK package.
+
+## Authentication Model
+
+Use `EYEPOP_API_KEY` only in trusted server-side environments. Browser and mobile applications should request an EyePop session from your backend and connect with `auth: { session }`.
+
+Persistent worker deployments can be selected with `EYEPOP_SESSION_UUID` in the trusted server environment.

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,12 @@ In project root:
 export EYEPOP_API_KEY=<your api key>
 ```
 
+For a provisioned persistent worker session, also set:
+
+```shell
+export EYEPOP_SESSION_UUID=<your session uuid>
+```
+
 ## In Node
 
 ```shell
@@ -44,9 +50,3 @@ open http://localhost:8000/examples/web/static/upload.html
 or
 
 open http://localhost:8000/examples/web/static/ingress.html
-
-In another terminal
-
-```shell
-open http://127.0.0.1:8000/examples/web/static/upload.html?eyepopUrl=(echo $EYEPOP_URL | jq -sRr @uri)
-```

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -1,43 +1,41 @@
 # EyePop Next.js Example
 
-This is a [Next.js](https://nextjs.org) project that demonstrates how to integrate with the EyePop SDK. It provides examples of uploading images and working with EyePop's AI-powered computer vision capabilities.
+This [Next.js](https://nextjs.org) example uploads images from the browser and renders EyePop inference results.
 
+The browser never receives an API key. The API key stays in the Next.js server environment, where `/api/eyepop-session` creates an EyePop session and returns session JSON to the client.
 
 ## Prerequisites
 
-- Node 18+
-- **EyePop API Key** - Authentication credential (required)
-- **EyePop Model UUID** - Specific AI model identifier (optional, defaults to 'eyepop.person:latest')
+- Node 22
+- EyePop API key for the server environment
+- Optional EyePop model alias or model UUID
 
 ## Getting Started
 
-First, install the dependencies:
+Install dependencies:
 
 ```bash
 npm install
 ```
 
-Then, set up your environment variables (see Environment Variables section below).
+Create `.env.local`:
 
-Finally, run the development server:
+```bash
+EYEPOP_API_KEY=your_api_key_here
+NEXT_PUBLIC_EYEPOP_MODEL_ALIAS=eyepop.person:latest
+```
+
+Or use a model UUID:
+
+```bash
+EYEPOP_API_KEY=your_api_key_here
+NEXT_PUBLIC_EYEPOP_MODEL_UUID=your_model_uuid_here
+```
+
+Run the development server:
 
 ```bash
 npm run dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-
-## Environment Variables
-
-This project requires the following environment variables to be set:
-
-- `NEXT_PUBLIC_EYEPOP_API_KEY` - Your EyePop API key (required)
-- `NEXT_PUBLIC_EYEPOP_MODEL_UUID` - The EyePop Model UUID (optional, defaults to 'eyepop.person:latest')
- 
-
-Create a `.env.local` file in the root of this project and add these variables:
-
-```bash
-NEXT_PUBLIC_EYEPOP_MODEL_UUID=your_model_uuid_here
-NEXT_PUBLIC_EYEPOP_API_KEY=your_api_key_here
-```

--- a/examples/nextjs/src/app/api/eyepop-session/route.ts
+++ b/examples/nextjs/src/app/api/eyepop-session/route.ts
@@ -1,0 +1,19 @@
+import { EyePop } from '@eyepop.ai/eyepop'
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+    const apiKey = process.env.EYEPOP_API_KEY
+    if (!apiKey) {
+        return NextResponse.json({ error: 'EYEPOP_API_KEY is required' }, { status: 500 })
+    }
+
+    const endpoint = await EyePop.workerEndpoint({
+        auth: { apiKey },
+    }).connect()
+
+    try {
+        return NextResponse.json(await endpoint.session())
+    } finally {
+        await endpoint.disconnect()
+    }
+}

--- a/examples/nextjs/src/app/page.tsx
+++ b/examples/nextjs/src/app/page.tsx
@@ -21,20 +21,18 @@ export default function Home() {
     // EyePop.ai setup function - generates session dynamically like webpack example
     const setup = async () => {
         try {
-            const apiKey = process.env.NEXT_PUBLIC_EYEPOP_API_KEY
             const modelUuid = process.env.NEXT_PUBLIC_EYEPOP_MODEL_UUID
-            if (!apiKey) {
-                throw new Error('EYEPOP_API_KEY environment variable is required')
+            const modelAlias = process.env.NEXT_PUBLIC_EYEPOP_MODEL_ALIAS || 'eyepop.person:latest'
+            const sessionResponse = await fetch('/api/eyepop-session')
+            if (!sessionResponse.ok) {
+                throw new Error('Unable to create EyePop session')
             }
+            const session = await sessionResponse.json()
+
             endpointRef.current = EyePop.workerEndpoint({
-                auth: { apiKey: apiKey },
+                auth: { session },
             })
             await endpointRef.current.connect()
-            const session = await endpointRef.current.session()
-
-            if (!session) {
-                throw new Error('Session not found')
-            }
 
             console.log('Session:', session)
 
@@ -49,10 +47,9 @@ export default function Home() {
                     modelUuid,
                 }
             } else {
-                console.log('Model UUID not found. It will be set to the default model.')
                 popComponent = {
                     type: PopComponentType.INFERENCE,
-                    model: 'eyepop.person:latest',
+                    model: modelAlias,
                 }
             }
 
@@ -77,7 +74,7 @@ export default function Home() {
                     {
                         error: 'Setup failed',
                         details: errorMessage,
-                        note: 'Please check your EYEPOP_API_KEY environment variable',
+                        note: 'Please check EYEPOP_API_KEY in the server environment',
                     },
                     null,
                     2,

--- a/examples/node/pop_demo.ts
+++ b/examples/node/pop_demo.ts
@@ -222,6 +222,10 @@ const { positionals, values } = parseArgs({
             type: 'string',
             short: 'u',
         },
+        session_uuid: {
+            type: 'string',
+            short: 's',
+        },
         pop: {
             type: 'string',
             short: 'p',
@@ -307,7 +311,7 @@ const { positionals, values } = parseArgs({
             type: 'string',
         },
         roi: {
-          type: 'string',
+            type: 'string',
         },
         help: {
             type: 'boolean',
@@ -327,6 +331,7 @@ function printHelpAndExit(message?: string, exitCode: number = -1) {
             '\n\t-l or --localPath=[path] to run inference on a local image file' +
             '\n\t-a or --assetUuid=[uuid] to run inference on a asset by its Uuid' +
             '\n\t-u --url=[url] to run inference on a remote image url' +
+            '\n\t-s --session-uuid=[SESSION UUID] to use a permanent session' +
             '\n\t-p --pop=[pop] to run one of the example pos, one of ' +
             Object.keys(POP_EXAMPLES) +
             '\n\t-m --modelUuid=[model uuid] to run inference using a specific model uuid' +
@@ -516,8 +521,8 @@ function rectangle_roi_area(arg: string): Area {
     } else {
       printHelpAndExit(`unknown pop ${parameters.pop}`);
     }
-  } else {
-    printHelpAndExit("required: --modelUuid --abilityUuid or --model or --ability or --pop");
+  } else if (!parameters.session_uuid) {
+    printHelpAndExit("required: --modelUuid --abilityUuid or --model or --ability or --pop pt --session-uuid");
   }
   console.log(JSON.stringify(pop, undefined, 2))
   let example_input;
@@ -581,13 +586,16 @@ function rectangle_roi_area(arg: string): Area {
 
   const endpoint = await EyePop.workerEndpoint({
     logger: logger,
+    sessionUuid: parameters.session_uuid
   })
     .onStateChanged((fromState: EndpointState, toState: EndpointState) => {
       logger.debug("Endpoint changed state %s -> %s", fromState, toState);
     })
     .connect();
   try {
-    await endpoint.changePop(pop);
+    if (pop) {
+        await endpoint.changePop(pop);
+    }
     const results = await endpoint.process({
         source: example_input,
         componentParams: sourceParams,

--- a/examples/react_native/upload-example/app/(tabs)/index.tsx
+++ b/examples/react_native/upload-example/app/(tabs)/index.tsx
@@ -45,7 +45,6 @@ export default function homeScreen() {
     useEffect(() => {
         const endpoint = EyePop.workerEndpoint({
             auth: { apiKey: process.env.EXPO_PUBLIC_EYEPOP_API_KEY || '' },
-            eyepopUrl: process.env.EXPO_PUBLIC_EYEPOP_URL || undefined,
         })
         setSpinner('Connecting to EyePop...')
         endpoint.connect().then(value => {

--- a/examples/web/static/dataset.html
+++ b/examples/web/static/dataset.html
@@ -53,7 +53,6 @@
         const urlParams = new URLSearchParams(queryString);
         let account_uuid = urlParams.get('accountUUID') || defaultAccountUUID;
         let dataset_uuid = urlParams.get('datasetUUID') || null;
-        const eyepopUrl = urlParams.get('eyepopUrl') || undefined;
         var currDataset = null;
         var endpoint = null;
 
@@ -96,7 +95,6 @@
             endpoint = await EyePop.dataEndpoint({
                 auth: auth,
                 accountId: account_uuid,
-                eyepopUrl: 'https://web-api.staging.eyepop.xyz',
             }).connect();
 
             if (!dataset_uuid) {
@@ -483,7 +481,7 @@
 
             var datasetDiv = document.createElement('div');
             datasetDiv.innerHTML = "<span style='font-weight: bold; font-size: larger;'>" + dataset.name + "</span><br /> " + 
-                "<a href='https://staging.dashboard.eyepop.ai/wizardModel?step=autoLabel&accountUUID="+account_uuid+"&datasetUUID="+dataset.uuid+"' target='_blank'>" + dataset.uuid +"</a>";
+                dataset.uuid;
             listDatasetsResult.appendChild(datasetDiv);
             //add delete button to each dataset
             var deleteButton = document.createElement('button');

--- a/examples/web/static/ingress.js
+++ b/examples/web/static/ingress.js
@@ -68,14 +68,9 @@ async function populateDevices() {
 
 async function connect(event) {
     if (!endpoint) {
-        const queryString = window.location.search
-        const urlParams = new URLSearchParams(queryString)
-        const eyepopUrl = urlParams.get('eyepopUrl') || undefined
-
         endpoint = await EyePop.workerEndpoint({
             auth: { oAuth2: true },
             popId: TransientPopId.transient,
-            eyepopUrl: eyepopUrl,
         }).onStateChanged((from, to) => {
             console.log('Endpoint state transition from ' + from + ' to ' + to)
         })

--- a/examples/web/static/modeltest.html
+++ b/examples/web/static/modeltest.html
@@ -64,10 +64,8 @@
             }]
         }
 
-        EyePop.endpoint({
+        EyePop.workerEndpoint({
             auth: auth,
-            popId: "transient",
-            eyepopUrl: 'https://web-api.staging.eyepop.xyz',
         }).connect().then((endpoint) => postConnect(endpoint))
 
         function postConnect(endpoint) {

--- a/examples/web/static/multidownload.html
+++ b/examples/web/static/multidownload.html
@@ -77,7 +77,6 @@
 
             endpoint = await EyePopData.endpoint({
                 auth: auth,
-                eyepopDataUrl: 'https://data.api.eyepop.xyz'
             }).connect();
 
             // Test healthz function

--- a/examples/web/static/upload.js
+++ b/examples/web/static/upload.js
@@ -41,13 +41,8 @@ async function setup() {
 
 async function connect(event) {
     if (!endpoint) {
-        const queryString = window.location.search
-        const urlParams = new URLSearchParams(queryString)
-        const eyepopUrl = urlParams.get('eyepopUrl') || undefined
-
         endpoint = await EyePop.workerEndpoint({
             auth: { oAuth2: true },
-            eyepopUrl: eyepopUrl,
         }).onStateChanged((from, to) => {
             console.log('Endpoint state transition from ' + from + ' to ' + to)
         })

--- a/examples/web/static/workshopView.html
+++ b/examples/web/static/workshopView.html
@@ -110,8 +110,6 @@
             endpoint = await EyePop.dataEndpoint({
                 auth: auth,
                 accountId: account_uuid,
-                eyepopUrl: 'https://compute.staging.eyepop.xyz',
-                eyepopDataUrl: 'https://data.api.eyepop.xyz'
             }).connect();
 
             listDatasets(endpoint);

--- a/src/eyepop-render-2d/README.md
+++ b/src/eyepop-render-2d/README.md
@@ -46,7 +46,7 @@ const example_image_path = 'examples/example.jpg'
 
     context.drawImage(image, 0, 0)
 
-    const endpoint = await EyePop.endpoint().connect()
+    const endpoint = await EyePop.workerEndpoint().connect()
     try {
         let results = await endpoint.process({ source: { path: example_image_path } })
         for await (let result of results) {
@@ -93,7 +93,7 @@ const example_image_path = 'examples/example.jpg'
 
                 const endpoint = await EyePop.workerEndpoint({auth: {oAuth2: true}}).connect();
                 await endpoint.changePop({ components: [{
-                    type: PopComponentType.INFERENCE,
+                    type: 'inference',
                     model: 'eyepop.person:latest',
                     categoryName: 'person'
                 }]})
@@ -116,7 +116,7 @@ Change this rendering behaviour by passing in rendering rule(s), e.g.:
 
 ```javascript
 // ...
-Render2d.renderer(context, [Render2.renderFace()]).draw(result)
+Render2d.renderer(context, [Render2d.renderFace()]).draw(result)
 // ...
 ```
 
@@ -129,11 +129,11 @@ Most prebuild render classes provide a reasonable defaults, as shown below.
 
 ```typescript
 Render2d.renderBox({
-    showClass = true,
-    showConfidence = false,
-    showTraceId = false,
-    showNestedClasses = false,
-    target = '$..objects.*',
+    showClass: true,
+    showConfidence: false,
+    showTraceId: false,
+    showNestedClasses: false,
+    target: '$..objects.*',
 })
 ```
 
@@ -157,8 +157,8 @@ Render2d.renderHand({
 
 ```typescript
 Render2d.renderFace({
-    showLabels = false,
-    target = '$..objects[?(@.classLabel=="face")]',
+    showLabels: false,
+    target: '$..objects[?(@.classLabel=="face")]',
 })
 ```
 

--- a/src/eyepop-render-2d/package.json
+++ b/src/eyepop-render-2d/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@eyepop.ai/eyepop-render-2d",
-    "version": "3.14.7",
+    "version": "3.15.0",
     "description": "The Node.js / Typescript library for 2d rendering of EyePop.ai's inference API",
     "keywords": [
         "AI",
@@ -31,7 +31,7 @@
         "dev": "tsup && webpack; npx chokidar '**/*.ts' -i 'dist' -c 'npx tsup && webpack'"
     },
     "dependencies": {
-        "@eyepop.ai/eyepop": "3.14.7",
+        "@eyepop.ai/eyepop": "3.15.0",
         "@juggle/resize-observer": "^3.4.0",
         "@types/jsonpath": "^0.2.4",
         "canvas": "3.2.0",

--- a/src/eyepop/README.md
+++ b/src/eyepop/README.md
@@ -1,330 +1,227 @@
 # EyePop.ai Node SDK
 
-The EyePop.ai Node SDK provides convenient access to the EyePop.ai's inference API from applications written in the
-TypeScript or JavaScript language.
+The EyePop.ai Node SDK provides JavaScript and TypeScript access to EyePop worker sessions for image and video inference.
 
 ## Installation
 
 ### Node
-EyePop Sdk is tested with the LTS versions `node v20.11.0` and `npm v10.2.4`. Getting started with:
+
+The SDK is tested with Node 20 LTS and newer.
+
 ```shell
 npm install --save @eyepop.ai/eyepop
 ```
-See the [Node example folder](https://github.com/eyepop-ai/eyepop-sdk-node/blob/main/examples/node) for code examples. 
+
+See the [Node examples](https://github.com/eyepop-ai/eyepop-sdk-node/blob/main/examples/node) for runnable scripts.
 
 ### Browser
-EyePop Sdk supports all model browsers and can be used with Javascript w/o any additional dependencies:  
+
+Browser applications can use the bundled SDK directly:
+
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@eyepop.ai/eyepop/dist/eyepop.min.js"></script>
 ```
-See the [Web example folder](https://github.com/eyepop-ai/eyepop-sdk-node/tree/main/examples/web/static) for code examples. 
+
+API keys must not be used in browser code. Browser apps should connect with sessions created by your trusted backend.
 
 ### React Native
+
+React Native applications should use the React Native package:
+
 ```shell
-npm install --save @eyepop.ai/eyepop
+npm install --save @eyepop.ai/react-native-eyepop
 ```
 
-See the [ReactNative example folder](https://github.com/eyepop-ai/eyepop-sdk-node/tree/main/examples/react_native/upload-example) for code 
-examples and tips for to debug your configuration. 
+See the [React Native example](https://github.com/eyepop-ai/eyepop-sdk-node/tree/main/examples/react_native/upload-example).
 
+## Authentication
 
-## Configuration
+The SDK supports these authentication patterns:
 
-The EyePop SDK needs to be configured with the **Pop Id** and your **Authentication Credentials**. Credentials can
-be provided as:
+- API key authentication for trusted server-side code.
+- Persistent worker session selection for provisioned deployments.
+- Browser OAuth for dashboard users building local demos.
 
-1. **Api Key**, server side only because this key must be kept secret
-2. **Session generated from Api Key**, server side generated session transported to client over trusted channel
-3. **Current Browser Session**, for developer running client code in the same browser session loghed into their EyePop Dashboard.
+### Server-Side API Key
 
-### Configuration via Environment (Server Side)
+Set `EYEPOP_API_KEY` in your server environment. API keys are secrets and must not be exposed in browser bundles, mobile app bundles, or public repositories.
 
-While you can provide a api_key keyword argument, we recommend using dotenv to add EYEPOP_API_KEY="My API Key"
-to your .env file so that your API Key is not stored in source control. By default, the SDK will read the following environment variables:
+```shell
+export EYEPOP_API_KEY=<your_api_key>
+```
 
--   `EYEPOP_API_KEY`: Your Api Key. You can create Api Keys in the profile section of your EyePop dashboard.
--   `EYEPOP_URL`: (Optional) URL of the EyePop API service, if you want to use any other endpoint than production `http://api.eyepop.ai`
-
-### Authentication with Api Key
-
-Configuration and authorization with explicit defaults:
+For provisioned persistent worker sessions, also set `EYEPOP_SESSION_UUID`.
 
 ```typescript
 import { EyePop } from '@eyepop.ai/eyepop'
-;async () => {
-    const endpoint = EyePop.workerEndpoint({
-        // This is the default and can be omitted
-        auth: { apiKey: process.env['EYEPOP_API_KEY'] },
-    })
-    await endpoint.connect()
-    // do work ....
-    await endpoint.disconnect()
-}
-```
 
-Equivalent, but shorter:
-
-```typescript
-import { EyePop } from '@eyepop.ai/eyepop'
-;async () => {
-    const endpoint = await EyePop.workerEndpoint().connect()
-    // do work ....
-    await endpoint.disconnect()
-}
-```
-
-### Authentication with session generated from Api Key
-
-#### Server Side
-
-```javascript
-import { EyePop } from '@eyepop.ai/eyepop'
-
-const getSession = async function (req, res) {
-    const endpoint = await EyePop.workerEndpoint().connect()
-    res.setHeader('Content-Type', 'application/json')
-    res.writeHead(200)
-    res.end(JSON.stringify(await endpoint.session()))
-}
-const server = http.createServer(getSession)
-server.listen(8080, '127.0.0.1')
-```
-
-#### Client Side
-
-```javascript
-import { EyePop } from '@eyepop.ai/eyepop'
 ;(async () => {
-    const session = await (await fetch('http://127.0.0.1:8080')).json()
-    const endpoint = await EyePop.workerEndpoint({ auth: { session: session } }).connect()
-    // do work ....
-    await endpoint.disconnect()
+    const endpoint = await EyePop.workerEndpoint().connect()
+    try {
+        await endpoint.changePop({
+            components: [
+                {
+                    type: 'inference',
+                    model: 'eyepop.person:latest',
+                    categoryName: 'person',
+                },
+            ],
+        })
+
+        const results = await endpoint.process({ source: { path: 'examples/example.jpg' } })
+        for await (const result of results) {
+            console.log(result)
+        }
+    } finally {
+        await endpoint.disconnect()
+    }
 })()
 ```
 
-### Authentication with Current Browser Session
+You can also pass the key explicitly from server-side configuration:
+
+```typescript
+const endpoint = await EyePop.workerEndpoint({
+    auth: { apiKey: process.env.EYEPOP_API_KEY },
+}).connect()
+```
+
+### Persistent Sessions
+
+If EyePop has provisioned a persistent worker session for your deployment, set `EYEPOP_SESSION_UUID` in the trusted server environment or pass `sessionUuid` explicitly.
+
+```shell
+export EYEPOP_API_KEY=<your_api_key>
+export EYEPOP_SESSION_UUID=<your_session_uuid>
+```
+
+```typescript
+import { EyePop } from '@eyepop.ai/eyepop'
+
+;(async () => {
+    const endpoint = await EyePop.workerEndpoint({
+        sessionUuid: process.env.EYEPOP_SESSION_UUID,
+    }).connect()
+
+    try {
+        const results = await endpoint.process({ source: { path: 'sample.mp4' } })
+        for await (const result of results) {
+            console.log(result)
+        }
+    } finally {
+        await endpoint.disconnect()
+    }
+})()
+```
+
+Persistent sessions are normally preconfigured. In that case, process media directly and do not call `changePop()` unless your deployment is meant to accept runtime Pop changes.
+
+### Browser and Mobile Clients
+
+Do not put `EYEPOP_API_KEY` in browser or mobile application code. Create EyePop sessions from a trusted backend, then pass only the session JSON to the client.
+
+### Browser OAuth for Local Dashboard Demos
+
+Dashboard users can run local browser demos with the current browser session:
 
 ```html
-<!doctype html>
-<html lang="en">
-    <head>
-        <meta charset="UTF-8" />
-        <script src="https://cdn.jsdelivr.net/npm/@eyepop.ai/eyepop/dist/eyepop.min.js"></script>
-    </head>
-    <body>
-        <script>
-            document.addEventListener('DOMContentLoaded', async event => {
-                let endpoint = await EyePop.workerEndpoint({ auth: { oAuth2: true } }).connect()
-                await endpoint.changePop({ components: [{
-                    type: PopComponentType.INFERENCE,
-                    model: 'eyepop.person:latest',
-                    categoryName: 'person'
-                }]})
-                // do work ....
-                await endpoint.disconnect()
+<script>
+    document.addEventListener('DOMContentLoaded', async () => {
+        const endpoint = await EyePop.workerEndpoint({ auth: { oAuth2: true } }).connect()
+        try {
+            await endpoint.changePop({
+                components: [
+                    {
+                        type: 'inference',
+                        model: 'eyepop.person:latest',
+                        categoryName: 'person',
+                    },
+                ],
             })
-        </script>
-    </body>
-</html>
-```
-
-To use an alternative environment, e.g. STAGING vs PRODUCTION, pass in the adjusted Auth0 configuration:
-
-```javascript
-// ...
-let endpoint = await EyePop.workerEndpoint({
-    auth: {
-        oAuth2: {
-            audience: 'https://dev-app.eyepop.ai',
-            domain: 'dev-eyepop.us.auth0.com',
-            clientId: 'jktx3YO2UnbkNPvr05PQWf26t1kNTJyg',
+        } finally {
+            await endpoint.disconnect()
         }
-    }
-}).connect()
-// ...
+    })
+</script>
 ```
 
-## Usage Examples
+## Processing Media
 
-### Uploading and processing one single image
+### Local Files
 
 ```typescript
-import { EyePop } from '@eyepop.ai/eyepop'
-
-const example_image_path = 'examples/example.jpg'
-
-;(async () => {
-    const endpoint = await EyePop.workerEndpoint().connect()
-    try {
-        await endpoint.changePop({ components: [{
-          type: PopComponentType.INFERENCE,
-          model: 'eyepop.person:latest',
-          categoryName: 'person'
-        }]})
-        let results = await endpoint.process({ source: { path: example_image_path } })
-        for await (let result of results) {
-            console.log(result)
-        }
-    } finally {
-        await endpoint.disconnect()
-    }
-})()
+const results = await endpoint.process({ source: { path: 'examples/example.jpg' } })
+for await (const result of results) {
+    console.log(result)
+}
 ```
 
-1. `EyePop.workerEndpoint()` returns a local endpoint object, that will authenticate with the Api Key found in
-   EYEPOP_API_KEY.
-2. Call `endpoint.connect()` before any job is submitted and `endpoint.disconnect()` to release all resources.
-3. Call `endpoint.changePop(...)` to define the Pop and its components to be executed by the endpoint, in this example
-   to use the ability `eyepop.person` to find all instances of persons in images and videos.
-4.`endpoint.process({ source: {path:'examples/example.jpg'} })` initiates the upload to the local file to the worker service.
-   The image will be queued and processed immediately when the worker becomes available.
-   The result of endpoint.upload() implements `AsyncIterable<Prediction>` which can be iterated with 'for await' as
-   shown in the example above. Predictions will become available when the submitted file becomes processed by the worker
-   and results are efficiently streamed back to the calling client. If the uploaded file is a video
-   e.g. 'video/mp4' or image container format e.g. 'image/gif', the client will receive one prediction per image frame
-   until the entire file has been processed.
+`process()` returns an `AsyncIterable` of predictions. Images normally produce one prediction. Videos and animated image containers produce one prediction per frame.
 
-5. Alternatively to `path` process() also accepts a readable stream with a mandatory mime-type:
+### Readable Streams
+
+Streams require an explicit MIME type:
 
 ```typescript
-// ...
-let stream = fs.createReadStream(example_image_path)
-endpoint.upload({ source: { stream: readableStream, mimeType: 'image/jpeg' } })
-// ...
+import fs from 'node:fs'
+
+const stream = fs.createReadStream('examples/example.jpg')
+const results = await endpoint.process({
+    source: { stream, mimeType: 'image/jpeg' },
+})
 ```
 
-Note: since v0.21.0 `EyePop.workerEndpoint()` was introduced and replaces `EyePop.endpoint()` which is now deprecated.
-Support for `EyePop.endpoint()` will be removed in v1.0.0.
+### Public URLs
 
-### Visualizing Results
-
-Visualization components are provided as separate modules. Please refer to the module's documentation for usage examples.
-
--   [EyePop Render 2d](https://www.npmjs.com/package/@eyepop.ai/eyepop-render-2d)
-
-### Asynchronous uploading and processing of images
-
-The above _synchronous_ way, process() then iterate all results, is great for individual images or reasonable
-sized batches. For larger batch sizes, or continuous stream of images, don't `await` the results but instead
-use `then()` on the returned promise.
+Public HTTP(S), RTSP, and RTMP URLs can be processed without uploading the file from your application.
 
 ```typescript
-import { EyePop } from '@eyepop.ai/eyepop'
-
-const example_image_path = 'examples/example.jpg'
-
-;(async () => {
-    const endpoint = await EyePop.workerEndpoint().connect()
-    try {
-        for (let i = 0; i < 100; i++) {
-            endpoint.process({ source: { path: example_image_path } }).then(async results => {
-                for await (let result of results) {
-                    console.log(`result for #${i}`, result)
-                }
-            })
-        }
-    } finally {
-        await endpoint.disconnect()
-    }
-})()
-```
-
-This will result in a most efficient processing, i.e. uploads will be processed in parallel (up to five HTTP
-connections per endpoint) and results will be processed by your code as soon as they are available.
-
-### Loading images from URLs
-
-Alternatively to uploading files, you can also submit a publicly accessible URL for processing. Supported protocols are:
-
--   HTTP(s) URLs with response Content-Type image/_ or video/_
--   RTSP (live-streaming)
--   RTMP (live-streaming)
-
-```typescript
-import { EyePop } from '@eyepop.ai/eyepop'
-
-const example_image_url = 'https://farm2.staticflickr.com/1080/1301049949_532835a8b5_z.jpg'
-
-;(async () => {
-    const endpoint = await EyePop.workerEndpoint().connect()
-    try {
-        let results = await endpoint.process({ source: { url: example_image_url } })
-        for await (let result of results) {
-            console.log(result)
-        }
-    } finally {
-        await endpoint.disconnect()
-    }
-})()
-```
-
-### Processing Videos
-
-You can process videos via upload or public URLs. This example shows how to process all video frames of a file
-retrieved from a public URL.
-
-```typescript
-import { EyePop } from '@eyepop.ai/eyepop'
-
-const example_video_url = 'https://demo-eyepop-videos.s3.amazonaws.com/test1_vlog.mp4'
-
-;(async () => {
-    const endpoint = await EyePop.workerEndpoint().connect()
-    try {
-        let results = await endpoint.process({ source: { url: example_video_url } })
-        for await (let result of results) {
-            console.log(result)
-        }
-    } finally {
-        await endpoint.disconnect()
-    }
-})()
+const results = await endpoint.process({
+    source: { url: 'https://demo-eyepop-videos.s3.amazonaws.com/test1_vlog.mp4' },
+})
 ```
 
 ### Canceling Jobs
 
-Any job that has been queued or is in-progress can be cancelled. E.g. stop the video processing after
-predictions have been processed for 10 seconds duration of the video.
+Queued and in-progress jobs can be cancelled from the result iterator:
 
 ```typescript
-import { EyePop } from '@eyepop.ai/eyepop'
+const results = await endpoint.process({
+    source: { url: 'https://demo-eyepop-videos.s3.amazonaws.com/test1_vlog.mp4' },
+})
 
-const example_video_url = 'https://demo-eyepop-videos.s3.amazonaws.com/test1_vlog.mp4'
-
-;(async () => {
-    const endpoint = EyePop.workerEndpoint().connect()
-    try {
-        let results = await endpoint.process({ source: { url: example_video_url } })
-        for await (let result of results) {
-            console.log(result)
-            if (result['seconds'] >= 10.0) {
-                results.cancel()
-            }
-        }
-    } finally {
-        await endpoint.disconnect()
+for await (const result of results) {
+    console.log(result)
+    if ((result.seconds ?? 0) >= 10) {
+        results.cancel()
     }
-})()
+}
 ```
 
-## Other Usage Options
+## Endpoint Options
 
-#### Auto start workers
+By default, `EyePop.workerEndpoint().connect()` starts a worker when needed and cancels queued jobs on that worker when it connects.
 
-By default, `EyePop.workerEndpoint().connect()` will start a worker if none is running yet. To disable this behavior
-create an endpoint with `EyePop.endpoint({autoStart: false})`.
+Disable worker startup:
 
-#### Stop pending jobs
+```typescript
+const endpoint = await EyePop.workerEndpoint({ autoStart: false }).connect()
+```
 
-By default, `EyePop.workerEndpoint().connect()` will cancel all currently running or queued jobs on the worker.
-It is assumed that the caller _takes full control_ of that worker. To disable this behavior create an endpoint with
-`EyePop.endpoint({stopJobs: false})`.
+Keep pending jobs:
 
-## Data endpoint (PREVIEW)
+```typescript
+const endpoint = await EyePop.workerEndpoint({ stopJobs: false }).connect()
+```
 
-To support managing your own datasets and control model optimization v0.21.0 introduces `EyePop.dataEndpoint()`,
-an experimental pre-release which is subject to change. An officially supported version will be released with v2.0.0
+## Visualization
 
-## Composable Pops (PREVIEW)
+Rendering helpers are provided by [@eyepop.ai/eyepop-render-2d](https://www.npmjs.com/package/@eyepop.ai/eyepop-render-2d).
 
-See [Composable Pops](composable-pops.md) for a preview of client side composability of pops, introduced in v1.0.0.
+## Data Endpoint Preview
+
+`EyePop.dataEndpoint()` provides preview support for dataset management and model optimization workflows. This API is experimental and subject to change.
+
+## Composable Pops Preview
+
+See [Composable Pops](composable-pops.md) for a preview of client-side Pop composition.

--- a/src/eyepop/index.ts
+++ b/src/eyepop/index.ts
@@ -174,7 +174,13 @@ export namespace EyePop {
                 throw new Error('auth option or EYEPOP_API_KEY environment variable is required')
             }
         }
-        if (opts.popId === undefined) {
+
+        if (opts.sessionUuid === undefined) {
+            opts.sessionUuid = readEnv('EYEPOP_SESSION_UUID')
+        }
+
+        // TODO remove pop id support in 3.16
+        if (opts.popId === undefined && opts.sessionUuid === undefined) {
             opts.popId = readEnv('EYEPOP_POP_ID') || TransientPopId.Transient
         }
 

--- a/src/eyepop/options.ts
+++ b/src/eyepop/options.ts
@@ -54,11 +54,6 @@ export interface PlatformSupport {
 export interface Options {
     auth?: Authentication | undefined
 
-    /**
-     * Override the default base URL for the API, e.g., "https://api.eyepop.ai/"
-     *
-     * Defaults to process.env['EYEPOP_URL'].
-     */
     eyepopUrl?: string | undefined
 
     jobQueueLength?: number

--- a/src/eyepop/package.json
+++ b/src/eyepop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@eyepop.ai/eyepop",
-    "version": "3.14.7",
+    "version": "3.15.0",
     "description": "The official Node.js / Typescript library for EyePop.ai's inference API",
     "keywords": [
         "AI",

--- a/src/eyepop/worker/worker_endpoint.ts
+++ b/src/eyepop/worker/worker_endpoint.ts
@@ -617,7 +617,7 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
         this._pipeline = null
         if (session.pipeline_uuid) {
             this._pipelineId = session.pipeline_uuid
-        } if (session.pipelines) {
+        } else if (session.pipelines) {
             this._pipelineId = session.pipelines[0].pipeline_id
         } else {
             this._pipelineId = null

--- a/src/eyepop/worker/worker_endpoint.ts
+++ b/src/eyepop/worker/worker_endpoint.ts
@@ -1,4 +1,4 @@
-import { LocalAuth } from '../options'
+import { HttpClient, LocalAuth } from '../options'
 import { EndpointState, Session } from '../types'
 import { AbstractJob, LoadFromAssetUuidJob, LoadFromJob, LoadMediaStreamJob, UploadJob } from './jobs'
 import { resolvePath } from '../shims/local_file'
@@ -61,6 +61,8 @@ interface ComputeSession {
     uptime: number
     pipeline_ttl?: number | undefined
     session_active: boolean
+    persistent?: boolean
+    pipelines?: {pipeline_id: string}[]
 }
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
@@ -68,7 +70,6 @@ const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
     private _baseUrl: string | null
     private _pipelineId: string | null
-
     private _popName: string | null
 
     private _pipeline: Pipeline | null
@@ -213,7 +214,7 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
 
     private async processV1(source: Source, params?: ComponentParams[]): Promise<ResultStream> {
         if ((source as FileSource).file !== undefined) {
-            return this.uploadFile(source as FileSource, {componentParams: params})
+            return this.uploadFile(source as FileSource, { componentParams: params })
         } else if ((source as StreamSource).stream !== undefined) {
             return this.uploadStream(source as StreamSource, { componentParams: params })
         } else if ((source as PathSource).path !== undefined) {
@@ -471,9 +472,12 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
 
     protected override async reconnect(): Promise<WorkerEndpoint> {
         if (this.options().popId == TransientPopId.Transient) {
-            await this.startComputeSession()
+            await this.getComputeSession()
             this._pipelineId = await this.startTransientPipeline()
+        } else if (this.options().sessionUuid) {
+            await this.getComputeSession()
         } else {
+            // TDOD remove pop id support in 3.16
             await this.startWebApiSessionWithPopId()
         }
         this.updateState()
@@ -581,17 +585,54 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
     private static WAIT_FOR_IS_READY: number = 60 * 1000
     private static CHECK_FOR_IS_READY_INTERVAL: number = 250
 
-    private async startComputeSession(): Promise<void> {
+    private async getComputeSession(): Promise<void> {
         if (!this._client) {
             throw new Error('endpoint not initialized')
         }
+        let session: ComputeSession
+        let headers: any
+        const sessionUuid = this.options().sessionUuid
+        if (sessionUuid) {
+            [session, headers] = await this.getPermanentComputeSession(this._client, sessionUuid)
+        } else {
+            [session, headers] = await this.getOnDemandComputeSession(this._client)
+        }
+        let isReady: boolean = false
+        const deadline: number = Date.now() + WorkerEndpoint.WAIT_FOR_IS_READY
+        while (!isReady) {
+            const health_url = `${session.session_endpoint}/health`
+            const response = await this._client.fetch(health_url, {
+                headers: headers,
+            })
+            if (response.status < 300) {
+                isReady = true
+            } else if (Date.now() > deadline) {
+                throw new Error(`Created session ${session.session_uuid} did not become healthy after ${WorkerEndpoint.WAIT_FOR_IS_READY / 1000} seconds`)
+            } else {
+                this._logger.debug(`session ${session.session_uuid} health check status ${response.status}, wait and poll for update`)
+                await sleep(WorkerEndpoint.CHECK_FOR_IS_READY_INTERVAL)
+            }
+        }
+        this._baseUrl = session.session_endpoint
+        this._pipeline = null
+        if (session.pipeline_uuid) {
+            this._pipelineId = session.pipeline_uuid
+        } if (session.pipelines) {
+            this._pipelineId = session.pipelines[0].pipeline_id
+        } else {
+            this._pipelineId = null
+        }
+    }
+
+    private async getOnDemandComputeSession(httpClient: HttpClient): Promise<[ComputeSession, any]> {
         let session: ComputeSession | null = null
+
         const sessionsUrl = `${this.eyepopUrl()}/v1/sessions`
         this._requestLogger.debug('fetching sessions from: %s', sessionsUrl)
         const headers = {
             Authorization: await this.authorizationHeader(),
         }
-        let response = await this._client.fetch(sessionsUrl, {
+        let response = await httpClient.fetch(sessionsUrl, {
             headers: headers,
         })
         let sessions: ComputeSession[]
@@ -606,11 +647,10 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
             const response_content = await response.json()
             sessions = response_content as ComputeSession[]
         }
-        console.log(sessions)
         if (sessions.length > 0) {
-            this._logger.debug(`User has ${sessions.length} sessions, inspecting for active session`)
+            this._logger.debug(`User has ${sessions.length} sessions, inspecting for usable session`)
             for (let s of sessions) {
-                if (!WorkerEndpoint.SESSION_DEAD.has(s.session_status)) {
+                if (!WorkerEndpoint.SESSION_DEAD.has(s.session_status) && !s.persistent) {
                     session = s
                     this._logger.debug(`Use active session ${s.session_uuid} with pipeline ${s.pipeline_uuid}`)
                     break
@@ -619,7 +659,7 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
         }
         if (!session) {
             this._requestLogger.debug('creating a new session at: %s', sessionsUrl)
-            response = await this._client.fetch(`${sessionsUrl}?wait=true`, {
+            response = await httpClient.fetch(`${sessionsUrl}?wait=true`, {
                 headers: headers,
                 method: 'POST',
             })
@@ -638,29 +678,32 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
         if (!session) {
             throw new Error('unexpected undefined session')
         }
-        let isReady: boolean = false
-        const deadline: number = Date.now() + WorkerEndpoint.WAIT_FOR_IS_READY
-        while (!isReady) {
-            const health_url = `${session.session_endpoint}/health`
-            response = await this._client.fetch(health_url, {
-                headers: headers,
-            })
-            if (response.status < 300) {
-                isReady = true
-            } else if (Date.now() > deadline) {
-                throw new Error(`Created session ${session.session_uuid} did not become healthy after ${WorkerEndpoint.WAIT_FOR_IS_READY / 1000} seconds`)
-            } else {
-                this._logger.debug(`session ${session.session_uuid} health check status ${response.status}, wait and poll for update`)
-                await sleep(WorkerEndpoint.CHECK_FOR_IS_READY_INTERVAL)
-            }
+        return [session, headers]
+    }
+
+    private async getPermanentComputeSession(httpClient: HttpClient, sessionUuid: string): Promise<[ComputeSession, any]> {
+        let session: ComputeSession | null = null
+
+        const sessionUrl = `${this.eyepopUrl()}/v1/sessions/${sessionUuid}`
+        this._requestLogger.debug('fetching session from: %s', sessionUrl)
+        const headers = {
+            Authorization: await this.authorizationHeader(),
         }
-        this._baseUrl = session.session_endpoint
-        this._pipeline = null
-        if (session.pipeline_uuid) {
-            this._pipelineId = session.pipeline_uuid
+        let response = await httpClient.fetch(sessionUrl, {
+            headers: headers,
+        })
+        if (response.status == 404) {
+            this.updateState(EndpointState.Error)
+            throw new Error(`Unexpected status ${response.status} compute sessions ${sessionUuid} not found`)
+        } else if (response.status != 200) {
+            this.updateState(EndpointState.Error)
+            const message = await response.text()
+            throw new Error(`Unexpected status ${response.status} fetching compute sessions: ${message}`)
         } else {
-            this._pipelineId = null
+            const response_content = await response.json()
+            session = response_content as ComputeSession
         }
+        return [session, headers]
     }
 
     private async startTransientPipeline(): Promise<string> {

--- a/src/eyepop/worker/worker_options.ts
+++ b/src/eyepop/worker/worker_options.ts
@@ -6,9 +6,11 @@ export enum TransientPopId {
 
 export interface WorkerOptions extends Options {
     /**
-     * TODO: deprecated, defaults to process.env['EYEPOP_POP_ID'].
+     * TODO: deprecated, support for pop id will be removed in 3.16
      */
     popId?: string | TransientPopId | undefined
+
+    sessionUuid?: string | undefined
     autoStart?: boolean
     stopJobs?: boolean
     isLocalMode?: boolean

--- a/src/react-native-eyepop/README.md
+++ b/src/react-native-eyepop/README.md
@@ -40,8 +40,7 @@ Use the `EyePop` namespace from `react-native-eyepop` with the identical Api as 
 import { EyePop } from 'react-native-eyepop';
 
 const endpoint = EyePop.workerEndpoint({
-    auth: { apiKey: process.env.EXPO_PUBLIC_EYEPOP_API_KEY || '' },
-    eyepopUrl: process.env.EXPO_PUBLIC_EYEPOP_URL || undefined,
+    auth: { session },
 })
 
 // ....

--- a/src/react-native-eyepop/package.json
+++ b/src/react-native-eyepop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eyepop.ai/react-native-eyepop",
-  "version": "3.14.7",
+  "version": "3.15.0",
   "description": "The official Typescript library for EyePop.ai's inference API for React Native",
   "source": "./src/index.ts",
   "main": "./lib/commonjs/index.js",

--- a/src/react-native-eyepop/package.json
+++ b/src/react-native-eyepop/package.json
@@ -67,8 +67,8 @@
   },
   "dependencies": {
       "@azure/core-asynciterator-polyfill": "^1.0.2",
-      "@eyepop.ai/eyepop": "3.14.7",
-      "@eyepop.ai/eyepop-render-2d": "3.14.7",
+      "@eyepop.ai/eyepop": "3.15.0",
+      "@eyepop.ai/eyepop-render-2d": "3.15.0",
       "@types/react-native-canvas": "^0.1.14",
       "buffer": "^6.0.3",
       "react": "^19.2.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Release Notes - Version 3.15.0**

- **Permanent Session Support**: Added support for permanent sessions via the `EYEPOP_SESSION_UUID` environment variable or `sessionUuid` option in `WorkerOptions`, enabling persistent session management across connections.

- **CLI Enhancement**: The demo CLI now supports `--session-uuid`/`-s` flag to specify a session UUID when creating EyePop worker endpoints.

- **Compute-Session Refactoring**: Refactored session acquisition logic into separate methods (`getComputeSession()`, `getOnDemandComputeSession()`, `getPermanentComputeSession()`) to support both on-demand and permanent session flows with improved health polling.

- **ComputeSession Type Extension**: Extended `ComputeSession` type with optional `persistent` and `pipelines` fields to support new session selection and backfill behavior.

- **Deprecation Update**: Updated `WorkerOptions.popId` deprecation notice to specify removal in version 3.16, preparing for future sunset of pop-id support.

- **Package Version Bump**: Updated `@eyepop.ai/eyepop`, `@eyepop.ai/eyepop-render-2d`, and `@eyepop.ai/react-native-eyepop` to version 3.15.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eyepop-ai/eyepop-sdk-node/pull/176)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->