### PR TITLE
[sdk] Align prediction result types with live output

### DIFF
--- a/src/eyepop/index.ts
+++ b/src/eyepop/index.ts
@@ -17,6 +17,8 @@ export {
     StreamTime,
     Prediction,
     PredictedClass,
+    PredictedText,
+    PredictedEmbedding,
     PredictedObject,
     PredictedMesh,
     PredictedKeyPoint,

--- a/src/eyepop/types.ts
+++ b/src/eyepop/types.ts
@@ -62,24 +62,36 @@ export interface Prediction extends StreamTime {
      */
     source_height: number
     source_id?: string
+    source_url?: string
+    source_type?: string
+    system_timestamp?: number
     objects?: Array<PredictedObject>
     classes?: Array<PredictedClass>
     texts?: Array<PredictedText>
     meshs?: Array<PredictedMesh>
     keyPoints?: Array<PredictedKeyPoints>
+    embeddings?: Array<PredictedEmbedding>
+    motions?: Array<PredictedMotion>
 }
 
 export interface PredictedClass {
     id?: number
-    confidence: number
+    confidence?: number
     classLabel: string
     category?: string
 }
 
 export interface PredictedText {
     id?: number
-    confidence: number
+    confidence?: number
     text: string
+    category?: string
+}
+
+export interface PredictedEmbedding {
+    x?: number
+    y?: number
+    embedding: Array<number>
     category?: string
 }
 
@@ -96,20 +108,20 @@ export interface Mask {
 }
 
 export interface PredictedObject extends PredictedClass {
-    trackId: number | undefined
+    trackId?: number
     x: number
     y: number
     width: number
     height: number
     orientation?: number
-    outline: Array<Point2d> | undefined
-    contours: Array<Contour> | undefined
-    mask: Mask | undefined
-    objects: Array<PredictedObject> | undefined
-    classes: Array<PredictedClass> | undefined
-    texts: Array<PredictedText> | undefined
-    meshs: Array<PredictedMesh> | undefined
-    keyPoints: Array<PredictedKeyPoints> | undefined
+    outline?: Array<Point2d>
+    contours?: Array<Contour>
+    mask?: Mask
+    objects?: Array<PredictedObject>
+    classes?: Array<PredictedClass>
+    texts?: Array<PredictedText>
+    meshs?: Array<PredictedMesh>
+    keyPoints?: Array<PredictedKeyPoints>
 }
 
 export interface Point2d {
@@ -118,24 +130,28 @@ export interface Point2d {
 }
 
 export interface PredictedMesh {
-    category: string
-    id: number
-    confidence: number
+    category?: string
+    id?: number
+    confidence?: number
     points: Array<Point3d>
 }
 
 export interface Point3d extends Point2d {
-    z: number | undefined
+    z?: number
 }
 
 export interface PredictedKeyPoints {
-    category: string
-    type: string
+    category?: string
+    type?: string
     points: Array<PredictedKeyPoint>
 }
 
-export interface PredictedKeyPoint extends Point3d, PredictedClass {
-    visible: boolean | undefined
+export interface PredictedKeyPoint extends Point3d {
+    id?: number
+    confidence?: number
+    classLabel?: string
+    category?: string
+    visible?: boolean
 }
 
 export interface PredictedMotion {

--- a/tests/eyepop/types.prediction.test.ts
+++ b/tests/eyepop/types.prediction.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from '@jest/globals'
+import type { Prediction } from '../../src/eyepop'
+
+describe('Prediction result types', () => {
+    test('accepts the live PlayerU persistent session result shape', () => {
+        const frame = {
+            duration: 41708333,
+            objects: [
+                {
+                    category: 'ball',
+                    classLabel: 'ball',
+                    confidence: 0.8722,
+                    height: 45.751,
+                    orientation: 0,
+                    width: 57.836,
+                    x: 506.138,
+                    y: 349.121,
+                },
+                {
+                    category: 'paddle_spine',
+                    classLabel: 'paddle spine',
+                    confidence: 0.7347,
+                    height: 27.047,
+                    keyPoints: [
+                        {
+                            category: 'paddle_spine',
+                            points: [
+                                {
+                                    visible: true,
+                                    x: 936.551,
+                                    y: 652.47,
+                                },
+                                {
+                                    visible: true,
+                                    x: 896.837,
+                                    y: 625.423,
+                                },
+                            ],
+                        },
+                    ],
+                    orientation: 0,
+                    width: 39.714,
+                    x: 896.837,
+                    y: 625.423,
+                },
+            ],
+            seconds: 0.375375,
+            source_height: 1080,
+            source_id: 'a9297e9e-4f99-11f1-8bc3-da17dd8585f2',
+            source_width: 1920,
+            system_timestamp: 1778765682008756000,
+            timestamp: 375375000,
+        } satisfies Prediction
+
+        expect(frame.objects?.[1]?.keyPoints?.[0]?.points).toHaveLength(2)
+        expect(frame.system_timestamp).toBeDefined()
+    })
+})


### PR DESCRIPTION
## Summary
- Align Node SDK prediction result interfaces with live PlayerU pipeline output and Python SDK result models.
- Add a compile-time Jest fixture based on the raw JSONL prediction shape returned by the PlayerU persistent session.

## Changes
- Adds `system_timestamp`, optional source metadata, embeddings, and motions to `Prediction`.
- Loosens optional nested result fields like `trackId`, keypoint group `type`, mesh metadata, and keypoint labels/confidence.
- Exports `PredictedText` and `PredictedEmbedding` from the root SDK module.

## Test plan
- [x] `npm test -- tests/eyepop/types.prediction.test.ts tests/eyepop/worker/endpoint.connect.transient.test.ts tests/eyepop/worker/endpoint.connect.test.ts --runInBand`
- [x] `npm run --workspace @eyepop.ai/eyepop build`
- [x] Compared against published-package PlayerU smoke JSONL output from `customer-testing/nodejs-smoke-test/logs/1778765680582-results.jsonl`