### PR TITLE
docs: correct supported Node version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The EyePop.ai Node SDK lets Node.js applications process images and videos with 
 npm install @eyepop.ai/eyepop
 ```
 
-The SDK is tested with Node 20 LTS and newer.
+The SDK supports Node.js 18 and newer.
 
 ## Configure
 


### PR DESCRIPTION
## Summary
- align the top-level README with the package engine requirement
- state support for Node.js 18 and newer
- keep the change scoped to `README.md` only