### PR TITLE
[ci] finish trusted publishing setup for npm release

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       - run: npm install
       - run: npm run build -ws
       - run: npm test
@@ -22,11 +22,14 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org/
       - run: npm install
       - run: npm run build -ws


### PR DESCRIPTION
## Problem

The `[ci] use trusted publishing` change (8723d80) dropped the `NPM_TOKEN` auth from the publish step but never wired up OIDC. As a result `npm publish` ran **completely unauthenticated** and the npm registry rejected every `v3.15.1` release attempt with a masked `E404`:

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@eyepop.ai%2feyepop - Not found
```

(npm returns `404` instead of `401/403` for scoped packages when it can't authenticate.) All six release runs on 2026-06-23 failed at this step; `build` passed every time.

## Fix

- **Add `id-token: write`** permission to `publish-npm` — required for the job to mint the OIDC token npm trusted publishing exchanges for a one-time publish credential. This was the missing half of "trusted publishing".
- **Bump both jobs to `node-version: 24`** — trusted publishing needs npm ≥ 11.5.1, but Node 22 bundles npm 10.x (below the floor). Node 24 ships npm 11.5.x+, so no separate `npm install -g npm@latest` step is needed.

## Prerequisite (done)

Trusted publishers are configured on npmjs.com for all three published workspaces: `@eyepop.ai/eyepop`, `@eyepop.ai/eyepop-render-2d`, `@eyepop.ai/react-native-eyepop`.

## After merge

Re-trigger the release so `release: published` fires against the fixed workflow — recreate the `v3.15.1` tag + release on the merged commit (the workflow is pinned to the release's commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)