### PR TITLE
[ci] add repository field to published workspaces for provenance

### DIFF
--- a/src/eyepop-render-2d/package.json
+++ b/src/eyepop-render-2d/package.json
@@ -13,6 +13,11 @@
     "bugs": {
         "url": "https://github.com/eyepop-ai/eyepop-sdk-node/issues"
     },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/eyepop-ai/eyepop-sdk-node.git",
+        "directory": "src/eyepop-render-2d"
+    },
     "homepage": "https://github.com/eyepop-ai/eyepop-sdk-node#readme",
     "main": "./dist/eyepop.render2d.index.js",
     "module": "./dist/eyepop.render2d.index.mjs",

--- a/src/eyepop/package.json
+++ b/src/eyepop/package.json
@@ -11,7 +11,12 @@
     "author": "EyePop.ai",
     "license": "MIT",
     "bugs": {
-        "url": "https://git pullgithub.com/eyepop-ai/eyepop-sdk-node/issues"
+        "url": "https://github.com/eyepop-ai/eyepop-sdk-node/issues"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/eyepop-ai/eyepop-sdk-node.git",
+        "directory": "src/eyepop"
     },
     "homepage": "https://github.com/eyepop-ai/eyepop-sdk-node#readme",
     "main": "./dist/eyepop.index.js",

--- a/src/react-native-eyepop/package.json
+++ b/src/react-native-eyepop/package.json
@@ -54,7 +54,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/eyepop-ai/eyepop-sdk-node.git"
+    "url": "git+https://github.com/eyepop-ai/eyepop-sdk-node.git",
+    "directory": "src/react-native-eyepop"
   },
   "author": "EyePop.ai <info@eyepop.ai> (https://github.com/eyepop-ai)",
   "license": "MIT",


### PR DESCRIPTION
## Problem

With trusted publishing now authenticating correctly (OIDC works, provenance is signed), the `v3.15.1` release got one step further and failed at provenance **validation**:

```
npm error code E422
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@eyepop.ai%2feyepop
  Error verifying sigstore provenance bundle: Failed to validate repository information:
  package.json: "repository.url" is "", expected to match
  "https://github.com/eyepop-ai/eyepop-sdk-node" from provenance
```

Trusted publishing auto-enables npm **provenance**, which requires every published `package.json` to carry a `repository.url` matching the repo that built it. `@eyepop.ai/eyepop` and `@eyepop.ai/eyepop-render-2d` had **no** `repository` field, so `npm publish -ws` failed on the first package.

## Fix

- Add a `repository` field (with monorepo `directory`) to all three published workspaces: `@eyepop.ai/eyepop`, `@eyepop.ai/eyepop-render-2d`, `@eyepop.ai/react-native-eyepop` (the last already had the URL; added `directory` for consistency).
- Fix a corrupted `bugs.url` in `src/eyepop/package.json` (`https://git pullgithub.com/...` → `https://github.com/...`).

## Context

Follow-up to #183, which fixed the OIDC auth half (`id-token: write` + Node 24 / npm ≥ 11.5.1). That changed the failure from `E404` (unauthenticated) to this `E422` (provenance). This PR closes the gap.

## After merge

Recreate the `v3.15.1` tag + release on the merged commit so `release: published` re-runs against the corrected manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)