### PR TITLE
[ci] publish workspaces idempotently, skip already-published versions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -33,4 +33,15 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm install
       - run: npm run build -ws
-      - run: npm publish -ws
+      - name: Publish workspaces (skip versions already on the registry)
+        run: |
+          for ws in $(node -p "require('./package.json').workspaces.join(' ')"); do
+            name=$(node -p "require('./$ws/package.json').name")
+            version=$(node -p "require('./$ws/package.json').version")
+            if [ -n "$(npm view "$name@$version" version 2>/dev/null)" ]; then
+              echo "Skipping $name@$version — already published"
+            else
+              echo "Publishing $name@$version"
+              npm publish --workspace "$ws"
+            fi
+          done


### PR DESCRIPTION
## Problem

`npm publish -ws` aborts on the first workspace error. In the `v3.15.1` release, `@eyepop.ai/eyepop` published successfully, then `@eyepop.ai/eyepop-render-2d` failed (its npm trusted publisher wasn't registered yet), so the command stopped and `@eyepop.ai/react-native-eyepop` never published.

Now `@eyepop.ai/eyepop@3.15.1` exists on the registry, which makes the failure un-retryable: a re-run hits `E409 — cannot publish over existing version` on the *first* workspace and aborts before reaching the two that still need publishing.

## Fix

Replace `npm publish -ws` with a loop that checks the registry per workspace and only publishes a version that isn't already there:

```bash
for ws in $(node -p "require('./package.json').workspaces.join(' ')"); do
  name=$(node -p "require('./$ws/package.json').name")
  version=$(node -p "require('./$ws/package.json').version")
  if [ -n "$(npm view "$name@$version" version 2>/dev/null)" ]; then
    echo "Skipping $name@$version — already published"
  else
    npm publish --workspace "$ws"
  fi
done
```

Each `npm publish --workspace` still performs its own OIDC trusted-publishing exchange. This makes release re-runs safe and idempotent, and lets the in-flight `v3.15.1` release finish publishing `-render-2d` and `react-native-eyepop` without conflicting on the already-published core package.

## Required alongside this

The two remaining packages still need their npm **trusted publishers** registered (org `eyepop-ai`, repo `eyepop-sdk-node`, workflow `npm-publish.yml`, no environment) — only `@eyepop.ai/eyepop` was configured, which is why the others fell back to web auth (`E401`).

## Context

Third in the series fixing the trusted-publishing migration: #183 (OIDC auth) → #184 (provenance repository field) → this (idempotent multi-package publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)