### PR TITLE
[SDK]: Use compute-created transient pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+    pull_request:
+    push:
+        branches:
+            - main
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        timeout-minutes: 20
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  persist-credentials: false
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+
+            - name: Install dependencies
+              run: npm install
+
+            - name: Build core SDK
+              run: npm --workspace @eyepop.ai/eyepop run build
+
+            - name: Build render package
+              run: npm --workspace @eyepop.ai/eyepop-render-2d run build
+
+            - name: Typecheck React Native package
+              run: npm --workspace @eyepop.ai/react-native-eyepop run typecheck
+
+            - name: Run unit tests
+              run: npx jest --runInBand --testPathIgnorePatterns="<rootDir>/.worktrees"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -61,7 +61,7 @@ jobs:
                     --cpu-image tests/test.jpg \
                     --cpu-pop-file tests/fixtures/pops/localize-objects-modeless.json \
                     --cpu-expected-class person \
-                    --cpu-min-objects 1 \
+                    --cpu-min-objects 0 \
                     --cpu-min-confidence 0 \
                     --vlm-image tests/fixtures/images/angrykitten.jpg \
                     --vlm-pop-file tests/fixtures/pops/find-kittens-vlm.json \

--- a/.github/workflows/session-smoke.yml
+++ b/.github/workflows/session-smoke.yml
@@ -12,7 +12,7 @@ on:
                 default: production
                 type: environment
             sdk_version:
-                description: 'SDK package to test: latest, source, or an exact version like 3.15.1'
+                description: 'SDK package to test: latest, source, or an exact version like 3.16.0'
                 required: true
                 default: latest
                 type: string

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Run it:
 node quickstart.mjs
 ```
 
-Passing `pop` up front creates a transient worker session with the requested pipeline already scheduled. SDK-created transient sessions use compute-api with `wait=true&transient=true`.
+Passing `pop` up front creates a transient worker session with the requested pipeline already scheduled. SDK-created sessions use compute-api with `wait=true`; persistent deployments are created separately.
 
 ## Configure a Pop
 

--- a/README.md
+++ b/README.md
@@ -18,12 +18,6 @@ Set your EyePop API key in the server environment:
 export EYEPOP_API_KEY=<your_api_key>
 ```
 
-For a provisioned persistent worker session, also set the session UUID:
-
-```shell
-export EYEPOP_SESSION_UUID=<your_session_uuid>
-```
-
 API keys are secrets. Do not put `EYEPOP_API_KEY` in browser bundles, mobile app bundles, or public repositories.
 
 ## Quickstart
@@ -33,11 +27,21 @@ Create `quickstart.mjs`:
 ```javascript
 import { EyePop } from '@eyepop.ai/eyepop'
 
-const endpoint = await EyePop.workerEndpoint().connect()
+const endpoint = await EyePop.workerEndpoint({
+    pop: {
+        components: [
+            {
+                type: 'inference',
+                ability: 'eyepop.person:latest',
+                categoryName: 'person',
+            },
+        ],
+    },
+}).connect()
 
 try {
     const results = await endpoint.process({
-        source: { path: 'sample.mp4' },
+        source: { path: 'examples/example.jpg' },
     })
 
     for await (const result of results) {
@@ -54,7 +58,7 @@ Run it:
 node quickstart.mjs
 ```
 
-When `EYEPOP_SESSION_UUID` is set, `EyePop.workerEndpoint()` connects to that persistent session. Otherwise it creates a transient worker session.
+Passing `pop` up front creates a transient worker session with the requested pipeline already scheduled. SDK-created transient sessions use compute-api with `wait=true&transient=true`.
 
 ## Configure a Pop
 
@@ -75,6 +79,20 @@ const endpoint = await EyePop.workerEndpoint({
 ```
 
 Use `endpoint.changePop(pop)` when an already connected transient worker needs to switch Pops. Persistent sessions are usually preconfigured; process media directly unless your deployment is intended to accept runtime Pop changes.
+
+## Persistent Sessions
+
+For a provisioned persistent worker session, set the session UUID and connect without a transient pop:
+
+```shell
+export EYEPOP_SESSION_UUID=<your_session_uuid>
+```
+
+```javascript
+const endpoint = await EyePop.workerEndpoint().connect()
+```
+
+When `EYEPOP_SESSION_UUID` is set, `EyePop.workerEndpoint()` connects to that persistent session. Persistent deployments are normally created outside the SDK through the compute API or EyePop tooling.
 
 ## Module Docs
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,12 +16,26 @@ export EYEPOP_SESSION_UUID=<your session uuid>
 
 ## In Node
 
+Build the local SDK before running examples that import from `src/eyepop/dist`:
+
+```shell
+npm run build -w @eyepop.ai/eyepop
+```
+
 ```shell
 npx tsx examples/node/pop_demo.ts \
   --pop person \
   --output \
   --localPath examples/example.jpg
 ```
+
+To exercise a CPU ModelLess transient session:
+
+```shell
+npm run demo:cpu-session
+```
+
+This creates a transient staging session with a ModelLess pop, prompts for `person`, processes `examples/example.jpg`, prints the session and pipeline IDs, then deletes the transient session.
 
 ## With Webpack
 

--- a/examples/node/cpu_session_demo.mjs
+++ b/examples/node/cpu_session_demo.mjs
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+
+import { existsSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { resolve } from 'node:path'
+import { parseArgs } from 'node:util'
+
+const require = createRequire(import.meta.url)
+
+const DEFAULT_EYEPOP_URL = 'https://compute.staging.eyepop.xyz'
+const DEFAULT_IMAGE = 'examples/example.jpg'
+const DEFAULT_ABILITY = 'eyepop.localize-objects:latest'
+const DEFAULT_PROMPT = 'person'
+const DEFAULT_EXPECTED_CLASS = 'person'
+
+const { values } = parseArgs({
+    options: {
+        image: {
+            type: 'string',
+            short: 'i',
+            default: DEFAULT_IMAGE,
+        },
+        prompt: {
+            type: 'string',
+            short: 'p',
+            default: DEFAULT_PROMPT,
+        },
+        ability: {
+            type: 'string',
+            short: 'a',
+            default: DEFAULT_ABILITY,
+        },
+        expectedClass: {
+            type: 'string',
+            short: 'c',
+            default: DEFAULT_EXPECTED_CLASS,
+        },
+        minConfidence: {
+            type: 'string',
+            default: '0.5',
+        },
+        eyepopUrl: {
+            type: 'string',
+            default: process.env.EYEPOP_URL || DEFAULT_EYEPOP_URL,
+        },
+        noCleanup: {
+            type: 'boolean',
+            default: false,
+        },
+        requireMatch: {
+            type: 'boolean',
+            default: false,
+        },
+        json: {
+            type: 'boolean',
+            default: false,
+        },
+        help: {
+            type: 'boolean',
+            short: 'h',
+            default: false,
+        },
+    },
+})
+
+function printHelpAndExit() {
+    console.info(`CPU session demo for staging
+
+Usage:
+  npm run demo:cpu-session -- --image examples/example.jpg --prompt person
+
+Environment:
+  EYEPOP_API_KEY must be set. EYEPOP_URL defaults to ${DEFAULT_EYEPOP_URL}.
+
+Options:
+  -i, --image <path>          Image to process. Default: ${DEFAULT_IMAGE}
+  -p, --prompt <text>         ModelLess prompt. Default: ${DEFAULT_PROMPT}
+  -a, --ability <alias>       Ability alias. Default: ${DEFAULT_ABILITY}
+  -c, --expectedClass <name>  Class label to summarize. Default: ${DEFAULT_EXPECTED_CLASS}
+      --minConfidence <n>     Minimum confidence for the summary. Default: 0.5
+      --eyepopUrl <url>       Compute API URL. Default: EYEPOP_URL or staging
+      --noCleanup             Leave the transient session in staging
+      --requireMatch          Exit non-zero if the ModelLess pop returns no objects
+      --json                  Print the full prediction payload
+`)
+    process.exit(0)
+}
+
+function loadSdk() {
+    const sdkPath = resolve('src/eyepop/dist/eyepop.index.js')
+    if (!existsSync(sdkPath)) {
+        throw new Error('SDK build not found. Run `npm run build -w @eyepop.ai/eyepop` first.')
+    }
+    return require(sdkPath)
+}
+
+function buildCpuPop({ ability, prompt, expectedClass }) {
+    return {
+        components: [
+            {
+                id: 1,
+                type: 'inference',
+                ability,
+                categoryName: expectedClass,
+                params: {
+                    prompts: [{ prompt }],
+                },
+            },
+        ],
+    }
+}
+
+function sessionUuidFromBaseUrl(baseUrl) {
+    try {
+        const parsed = new URL(baseUrl)
+        return parsed.pathname.split('/').filter(Boolean)[0] || ''
+    } catch {
+        return ''
+    }
+}
+
+function objectLabel(object) {
+    for (const key of ['classLabel', 'category', 'categoryName', 'label', 'name']) {
+        if (typeof object?.[key] === 'string') {
+            return object[key]
+        }
+    }
+    return ''
+}
+
+function summarizePredictions(predictions, expectedClass, minConfidence) {
+    const expected = expectedClass.trim().toLowerCase()
+    const objects = predictions.flatMap(prediction => (Array.isArray(prediction.objects) ? prediction.objects : []))
+    const matches = objects.filter(object => {
+        const confidence = object?.confidence ?? 0
+        return objectLabel(object).trim().toLowerCase() === expected && typeof confidence === 'number' && confidence >= minConfidence
+    })
+    return {
+        predictionCount: predictions.length,
+        objectCount: objects.length,
+        matchingObjectCount: matches.length,
+        topMatches: matches
+            .slice()
+            .sort((left, right) => (right.confidence ?? 0) - (left.confidence ?? 0))
+            .slice(0, 5)
+            .map(object => ({
+                class: objectLabel(object),
+                confidence: object.confidence,
+                box: {
+                    x: object.x,
+                    y: object.y,
+                    width: object.width,
+                    height: object.height,
+                },
+            })),
+    }
+}
+
+async function cleanupSession(apiKey, eyepopUrl, sessionUuid) {
+    if (!sessionUuid) {
+        return { ok: false, result: 'missing_session_uuid' }
+    }
+    const response = await fetch(`${eyepopUrl.replace(/\/+$/, '')}/v1/sessions/${sessionUuid}`, {
+        method: 'DELETE',
+        headers: {
+            Authorization: `Bearer ${apiKey}`,
+            Accept: 'application/json',
+        },
+    })
+    const body = await response.text()
+    return {
+        ok: [200, 202, 204, 404].includes(response.status),
+        status: response.status,
+        result: response.status === 404 ? 'already_absent' : 'deleted',
+        body: body && response.status >= 300 ? body.slice(0, 300) : '',
+    }
+}
+
+async function main() {
+    if (values.help) {
+        printHelpAndExit()
+    }
+    const apiKey = process.env.EYEPOP_API_KEY
+    if (!apiKey) {
+        throw new Error('EYEPOP_API_KEY is required')
+    }
+
+    const imagePath = resolve(values.image)
+    if (!existsSync(imagePath)) {
+        throw new Error(`Image does not exist: ${values.image}`)
+    }
+
+    const minConfidence = Number(values.minConfidence)
+    if (!Number.isFinite(minConfidence) || minConfidence < 0 || minConfidence > 1) {
+        throw new Error('--minConfidence must be between 0 and 1')
+    }
+
+    const { EyePop } = loadSdk()
+    const pop = buildCpuPop(values)
+    const sessionName = `node-cpu-demo-${Date.now()}`
+    const eyepopUrl = values.eyepopUrl.replace(/\/+$/, '')
+    let endpoint
+    let sessionUuid = ''
+
+    console.info('CPU session demo')
+    console.info(`- environment_url: ${eyepopUrl}`)
+    console.info(`- image: ${values.image}`)
+    console.info(`- ability: ${values.ability}`)
+    console.info(`- prompt: ${values.prompt}`)
+
+    try {
+        endpoint = await EyePop.workerEndpoint({
+            eyepopUrl,
+            auth: { apiKey },
+            sessionName,
+            pop,
+        }).connect()
+
+        const session = await endpoint.session()
+        sessionUuid = sessionUuidFromBaseUrl(session.baseUrl)
+        console.info(`- session_uuid: ${sessionUuid || 'n/a'}`)
+        console.info(`- pipeline_id: ${session.pipelineId}`)
+
+        const stream = await endpoint.process({
+            source: { path: imagePath },
+        })
+        const predictions = []
+        for await (const prediction of stream) {
+            predictions.push(prediction)
+        }
+
+        const summary = summarizePredictions(predictions, values.expectedClass, minConfidence)
+        console.info(`- predictions: ${summary.predictionCount}`)
+        console.info(`- objects: ${summary.objectCount}`)
+        console.info(`- ${values.expectedClass} matches >= ${minConfidence}: ${summary.matchingObjectCount}`)
+        for (const [index, match] of summary.topMatches.entries()) {
+            console.info(`  ${index + 1}. ${match.class} confidence=${Number(match.confidence ?? 0).toFixed(4)} box=${JSON.stringify(match.box)}`)
+        }
+
+        if (values.json) {
+            console.info(JSON.stringify(predictions, null, 2))
+        }
+        if (values.requireMatch && summary.matchingObjectCount === 0) {
+            process.exitCode = 2
+        }
+    } finally {
+        if (endpoint) {
+            await endpoint.disconnect()
+        }
+        if (!values.noCleanup && sessionUuid) {
+            const cleanup = await cleanupSession(apiKey, eyepopUrl, sessionUuid)
+            console.info(`- cleanup: ${cleanup.result} (${cleanup.status || 'n/a'})`)
+            if (!cleanup.ok) {
+                process.exitCode = process.exitCode || 3
+            }
+        }
+    }
+}
+
+main().catch(error => {
+    console.error(error?.stack || error)
+    process.exit(1)
+})

--- a/examples/node/load_video_from_http.ts
+++ b/examples/node/load_video_from_http.ts
@@ -1,7 +1,17 @@
 import { EyePop } from '../../src/eyepop'
 
 async function load_video_from_url(video_url: string, seconds: number) {
-    const endpoint = await EyePop.workerEndpoint().connect()
+    const endpoint = await EyePop.workerEndpoint({
+        pop: {
+            components: [
+                {
+                    type: 'inference',
+                    ability: 'eyepop.person:latest',
+                    categoryName: 'person',
+                },
+            ],
+        },
+    }).connect()
     try {
         const results = await endpoint.process({source: { url: video_url }})
         for await (let result of results) {

--- a/examples/node/upload_image.ts
+++ b/examples/node/upload_image.ts
@@ -21,6 +21,15 @@ const example_image_path = process.argv[2]
 
     const endpoint = await EyePop.workerEndpoint({
         logger: logger,
+        pop: {
+            components: [
+                {
+                    type: 'inference',
+                    ability: 'eyepop.person:latest',
+                    categoryName: 'person',
+                },
+            ],
+        },
     })
         .onStateChanged((fromState: EndpointState, toState: EndpointState) => {
             logger.info('Endpoint changed state %s -> %s', fromState, toState)

--- a/examples/node/upload_video.js
+++ b/examples/node/upload_video.js
@@ -53,13 +53,24 @@ function upload_video(video_path, seconds) {
         var endpoint, results, _d, results_1, results_1_1, result, e_1_1;
         return __generator(this, function (_e) {
             switch (_e.label) {
-                case 0: return [4 /*yield*/, eyepop_1.EyePop.workerEndpoint({ logger: logger }).connect()];
+                case 0: return [4 /*yield*/, eyepop_1.EyePop.workerEndpoint({
+                        logger: logger,
+                        pop: {
+                            components: [
+                                {
+                                    type: 'inference',
+                                    ability: 'eyepop.person:latest',
+                                    categoryName: 'person',
+                                },
+                            ],
+                        },
+                    }).connect()];
                 case 1:
                     endpoint = _e.sent();
                     _e.label = 2;
                 case 2:
                     _e.trys.push([2, , 16, 18]);
-                    return [4 /*yield*/, endpoint.process({ path: video_path })];
+                    return [4 /*yield*/, endpoint.process({ source: { path: video_path } })];
                 case 3:
                     results = _e.sent();
                     _e.label = 4;

--- a/examples/node/upload_video.ts
+++ b/examples/node/upload_video.ts
@@ -5,7 +5,18 @@ import { pino } from 'pino'
 const logger = pino({ level: 'debug', name: 'eyepop-example' })
 
 async function upload_video(video_path: string, is_streaming: boolean, seconds: number) {
-    const endpoint = await EyePop.workerEndpoint({ logger: logger }).connect()
+    const endpoint = await EyePop.workerEndpoint({
+        logger: logger,
+        pop: {
+            components: [
+                {
+                    type: 'inference',
+                    ability: 'eyepop.person:latest',
+                    categoryName: 'person',
+                },
+            ],
+        },
+    }).connect()
     try {
         const results = await endpoint.process({
             source: {

--- a/examples/react_native/upload-example/README.md
+++ b/examples/react_native/upload-example/README.md
@@ -5,22 +5,22 @@ This is a simple EyePop get-started with ReactNative created with [`create-expo-
 ## Pre-requisites
 
 EyePop has been tested with `react-native==0.76.7` and `expo==52.0.36` and the EyePop SDK does not require
-any additional dependencies for its base functionality. There is no strict dependency on using `expo`, but 
+any additional dependencies for its base functionality. There is no strict dependency on using `expo`, but
 EyePop does not provide those tested configurations and examples (e.g. using `@react-native-community/cli`).
 
 ### Required packages
 
-EyePop provides a ReactNative specific package that replaces some underlying packages to support local 
-file access, WebRTC-based live streaming and uniform networking including fast streamed HTTP request and 
-response bodies. The latter is necessary because the EyePop protocol is designed to operate in streaming 
-mode for all media types and inference responses. 
+EyePop provides a ReactNative specific package that replaces some underlying packages to support local
+file access, WebRTC-based live streaming and uniform networking including fast streamed HTTP request and
+response bodies. The latter is necessary because the EyePop protocol is designed to operate in streaming
+mode for all media types and inference responses.
 
 ```shell
 npm i @eyepop.ai/react-native-eyepop --save
 ```
 
-In the current version, the application still has to include some extra libraries in their own `package.json`. 
-Although those packages are defined as `peerDependencies`, they will be included, but neither expo nor 
+In the current version, the application still has to include some extra libraries in their own `package.json`.
+Although those packages are defined as `peerDependencies`, they will be included, but neither expo nor
 react-native/cli will autolink their native implementations (_note: there must be a better solution, feedback from ReactNative experts is welcome_).
 
 Theses are all the dependencies to add to the application's `package.json`:
@@ -28,7 +28,7 @@ Theses are all the dependencies to add to the application's `package.json`:
 ```json
 {
   "dependencies": {
-    "@eyepop.ai/react-native-eyepop": "1.15.1",
+    "@eyepop.ai/react-native-eyepop": "3.16.0",
     "react-native-canvas": "^0.1.40",
     "react-native-file-access": "^3.1.1",
     "react-native-polyfill-globals": "^3.1.0",
@@ -51,7 +51,7 @@ Theses are all the dependencies to add to the application's `package.json`:
    ```bash
     npx expo run:android
    ```
-or 
+or
 ```bash
     npx expo run:ios
 ```

--- a/examples/react_native/upload-example/package.json
+++ b/examples/react_native/upload-example/package.json
@@ -16,9 +16,9 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.2",
-    "@eyepop.ai/eyepop": "1.15.3",
-    "@eyepop.ai/eyepop-render-2d": "1.15.3",
-    "@eyepop.ai/react-native-eyepop": "1.15.3",
+    "@eyepop.ai/eyepop": "3.16.0",
+    "@eyepop.ai/eyepop-render-2d": "3.16.0",
+    "@eyepop.ai/react-native-eyepop": "3.16.0",
     "@react-navigation/bottom-tabs": "^7.2.0",
     "@react-navigation/native": "^7.0.14",
     "@types/react-native-canvas": "^0.1.14",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     },
     "scripts": {
         "test": "jest",
+        "demo:cpu-session": "node examples/node/cpu_session_demo.mjs",
         "smoke:session": "node scripts/session-smoke.mjs",
         "format": "prettier --write '**/*.{js,ts,json,md}'"
     },

--- a/scripts/session-smoke.mjs
+++ b/scripts/session-smoke.mjs
@@ -183,8 +183,8 @@ function requireInputs(args) {
     if (!args.apiKey) {
         throw new Error('Missing EYEPOP_API_KEY')
     }
-    if (!Number.isFinite(args.minObjects) || args.minObjects < 1) {
-        throw new Error('--min-objects must be at least 1')
+    if (!Number.isFinite(args.minObjects) || args.minObjects < 0) {
+        throw new Error('--min-objects must be at least 0')
     }
     if (!Number.isFinite(args.minConfidence) || args.minConfidence < 0 || args.minConfidence > 1) {
         throw new Error('--min-confidence must be between 0.0 and 1.0')
@@ -197,8 +197,8 @@ function requireInputs(args) {
     }
     for (const scenario of selectedScenarioDefinitions(args)) {
         for (const step of scenario.steps) {
-            if (!Number.isFinite(step.minObjects) || step.minObjects < 1) {
-                throw new Error(`${scenario.name} ${step.name} min objects must be at least 1`)
+            if (!Number.isFinite(step.minObjects) || step.minObjects < 0) {
+                throw new Error(`${scenario.name} ${step.name} min objects must be at least 0`)
             }
             if (!Number.isFinite(step.minConfidence) || step.minConfidence < 0 || step.minConfidence > 1) {
                 throw new Error(`${scenario.name} ${step.name} min confidence must be between 0.0 and 1.0`)
@@ -290,6 +290,11 @@ function scenarioDefinitions(args) {
             name: 'cpu-then-gpu-upgrade',
             startMode: 'reconnect-per-step',
             steps: [cpuStep, gpuStep, cpuStep],
+        },
+        {
+            name: 'gpu-then-cpu-downgrade',
+            startMode: 'reconnect-per-step',
+            steps: [gpuStep, cpuStep],
         },
         {
             name: 'legacy-change-pop',

--- a/scripts/session-smoke.mjs
+++ b/scripts/session-smoke.mjs
@@ -749,12 +749,28 @@ async function runSmoke(args) {
     }
 
     const started = Date.now()
+    const preexistingTransientSessionUuids = await fetchTransientSessionUuids(args.apiKey, eyepopUrl)
     const summaries = []
     for (const scenario of scenarios) {
-        summaries.push(await runScenario(args, sdk, eyepopUrl, scenario))
+        summaries.push(await runScenario({ ...args, noCleanup: true }, sdk, eyepopUrl, scenario))
+    }
+
+    const suiteCleanup = []
+    if (!args.noCleanup) {
+        const createdSessionUuids = new Set(
+            summaries
+                .map(summary => summary.session_uuid)
+                .filter(sessionUuid => sessionUuid && !preexistingTransientSessionUuids.has(sessionUuid)),
+        )
+        for (const sessionUuid of createdSessionUuids) {
+            suiteCleanup.push({
+                session_uuid: sessionUuid,
+                ...(await deleteTransientSession(args.apiKey, eyepopUrl, sessionUuid)),
+            })
+        }
     }
     return {
-        ok: summaries.every(summary => summary.ok),
+        ok: summaries.every(summary => summary.ok) && suiteCleanup.every(cleanup => cleanup.ok),
         scenario: args.scenario,
         environment: args.environment,
         sdk_module: args.sdkModule,
@@ -762,8 +778,9 @@ async function runSmoke(args) {
         eyepop_url: eyepopUrl,
         session_name: args.sessionName,
         scenarios: summaries,
+        suite_cleanup: suiteCleanup,
         duration_seconds: Math.round((Date.now() - started) / 100) / 10,
-        error: summaries.find(summary => !summary.ok)?.error,
+        error: summaries.find(summary => !summary.ok)?.error || suiteCleanup.find(cleanup => !cleanup.ok)?.error,
     }
 }
 

--- a/scripts/session-smoke.mjs
+++ b/scripts/session-smoke.mjs
@@ -763,12 +763,26 @@ async function runSmoke(args) {
                 .filter(sessionUuid => sessionUuid && !preexistingTransientSessionUuids.has(sessionUuid)),
         )
         for (const sessionUuid of createdSessionUuids) {
-            suiteCleanup.push({
-                session_uuid: sessionUuid,
-                ...(await deleteTransientSession(args.apiKey, eyepopUrl, sessionUuid)),
-            })
+            try {
+                suiteCleanup.push({
+                    session_uuid: sessionUuid,
+                    ...(await withDeadline(
+                        deleteTransientSession(args.apiKey, eyepopUrl, sessionUuid),
+                        Date.now() + 30 * 1000,
+                        `deleting transient session ${sessionUuid}`,
+                    )),
+                })
+            } catch (error) {
+                suiteCleanup.push({
+                    session_uuid: sessionUuid,
+                    ok: false,
+                    result: 'error',
+                    error: errorSummary(error),
+                })
+            }
         }
     }
+    const failedCleanup = suiteCleanup.find(cleanup => !cleanup.ok)
     return {
         ok: summaries.every(summary => summary.ok) && suiteCleanup.every(cleanup => cleanup.ok),
         scenario: args.scenario,
@@ -780,7 +794,9 @@ async function runSmoke(args) {
         scenarios: summaries,
         suite_cleanup: suiteCleanup,
         duration_seconds: Math.round((Date.now() - started) / 100) / 10,
-        error: summaries.find(summary => !summary.ok)?.error || suiteCleanup.find(cleanup => !cleanup.ok)?.error,
+        error:
+            summaries.find(summary => !summary.ok)?.error ||
+            (failedCleanup ? failedCleanup.error || failedCleanup.body || `cleanup failed with status ${failedCleanup.status}` : undefined),
     }
 }
 

--- a/src/eyepop-render-2d/README.md
+++ b/src/eyepop-render-2d/README.md
@@ -46,7 +46,17 @@ const example_image_path = 'examples/example.jpg'
 
     context.drawImage(image, 0, 0)
 
-    const endpoint = await EyePop.workerEndpoint().connect()
+    const endpoint = await EyePop.workerEndpoint({
+        pop: {
+            components: [
+                {
+                    type: 'inference',
+                    ability: 'eyepop.person:latest',
+                    categoryName: 'person',
+                },
+            ],
+        },
+    }).connect()
     try {
         let results = await endpoint.process({ source: { path: example_image_path } })
         for await (let result of results) {

--- a/src/eyepop-render-2d/package.json
+++ b/src/eyepop-render-2d/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@eyepop.ai/eyepop-render-2d",
-    "version": "3.15.1",
+    "version": "3.16.0",
     "description": "The Node.js / Typescript library for 2d rendering of EyePop.ai's inference API",
     "keywords": [
         "AI",
@@ -36,7 +36,7 @@
         "dev": "tsup && webpack; npx chokidar '**/*.ts' -i 'dist' -c 'npx tsup && webpack'"
     },
     "dependencies": {
-        "@eyepop.ai/eyepop": "3.15.1",
+        "@eyepop.ai/eyepop": "3.16.0",
         "@juggle/resize-observer": "^3.4.0",
         "@types/jsonpath": "^0.2.4",
         "canvas": "3.2.0",

--- a/src/eyepop/README.md
+++ b/src/eyepop/README.md
@@ -50,7 +50,7 @@ Set `EYEPOP_API_KEY` in your server environment. API keys are secrets and must n
 export EYEPOP_API_KEY=<your_api_key>
 ```
 
-For provisioned persistent worker sessions, also set `EYEPOP_SESSION_UUID`.
+Create transient sessions with a pop when the worker endpoint is constructed. This lets EyePop schedule the right compute before media is processed.
 
 ```typescript
 import { EyePop } from '@eyepop.ai/eyepop'
@@ -79,6 +79,27 @@ import { EyePop } from '@eyepop.ai/eyepop'
 ```
 
 For transient sessions, pass `pop` when creating the endpoint whenever possible. Use `endpoint.changePop(pop)` only when an already connected transient worker needs to switch Pops.
+
+When `sessionUuid` is not provided, the SDK creates compute sessions with `POST /v1/sessions?wait=true&transient=true`.
+
+ModelLess CPU pops use the same constructor-pop path:
+
+```typescript
+const endpoint = await EyePop.workerEndpoint({
+    pop: {
+        components: [
+            {
+                type: 'inference',
+                ability: 'eyepop.localize-objects:latest',
+                categoryName: 'objects',
+                params: {
+                    prompts: [{ prompt: 'person' }],
+                },
+            },
+        ],
+    },
+}).connect()
+```
 
 You can also pass the key explicitly from server-side configuration:
 
@@ -117,6 +138,31 @@ import { EyePop } from '@eyepop.ai/eyepop'
 ```
 
 Persistent sessions are normally preconfigured. In that case, process media directly and do not call `changePop()` unless your deployment is meant to accept runtime Pop changes.
+
+Persistent deployments are created through compute-api or EyePop tooling. For example, a trusted server can create a persistent deployment with an inline pop and then pass the returned `session_uuid` to the SDK:
+
+```shell
+curl -sS -X POST "https://compute.eyepop.ai/v1/deployments?wait=true" \
+  -H "Authorization: Bearer $EYEPOP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "display_name": "node-modeless-deployment",
+    "pop": {
+      "components": [
+        {
+          "type": "inference",
+          "ability": "eyepop.localize-objects:latest",
+          "categoryName": "objects",
+          "params": {
+            "prompts": [{ "prompt": "person" }]
+          }
+        }
+      ]
+    }
+  }'
+```
+
+The response includes `session_uuid`, `session_status`, `status_url`, and worker access metadata. Poll `status_url` until the deployment reaches `pipeline_ok`, then connect with `sessionUuid`.
 
 ### Browser and Mobile Clients
 
@@ -202,18 +248,18 @@ for await (const result of results) {
 
 ## Endpoint Options
 
-By default, `EyePop.workerEndpoint().connect()` starts a worker when needed and cancels queued jobs on that worker when it connects.
+By default, `EyePop.workerEndpoint({ pop }).connect()` starts a transient worker when needed and cancels queued jobs on that worker when it connects.
 
 Disable worker startup:
 
 ```typescript
-const endpoint = await EyePop.workerEndpoint({ autoStart: false }).connect()
+const endpoint = await EyePop.workerEndpoint({ pop, autoStart: false }).connect()
 ```
 
 Keep pending jobs:
 
 ```typescript
-const endpoint = await EyePop.workerEndpoint({ stopJobs: false }).connect()
+const endpoint = await EyePop.workerEndpoint({ pop, stopJobs: false }).connect()
 ```
 
 ## Visualization

--- a/src/eyepop/README.md
+++ b/src/eyepop/README.md
@@ -80,7 +80,7 @@ import { EyePop } from '@eyepop.ai/eyepop'
 
 For transient sessions, pass `pop` when creating the endpoint whenever possible. Use `endpoint.changePop(pop)` only when an already connected transient worker needs to switch Pops.
 
-When `sessionUuid` is not provided, the SDK creates compute sessions with `POST /v1/sessions?wait=true&transient=true`.
+When `sessionUuid` is not provided, the SDK creates compute sessions with `POST /v1/sessions?wait=true`.
 
 ModelLess CPU pops use the same constructor-pop path:
 

--- a/src/eyepop/compute/compute_session.ts
+++ b/src/eyepop/compute/compute_session.ts
@@ -179,7 +179,7 @@ export class ComputeSessionClient {
             if (createBody) {
                 request.body = createBody
             }
-            const query = 'wait=true&transient=true'
+            const query = 'wait=true'
             const response = await this.options.httpClient.fetch(`${sessionsUrl}?${query}`, request)
             if (response.status != 200) {
                 const message = await response.text()

--- a/src/eyepop/compute/compute_session.ts
+++ b/src/eyepop/compute/compute_session.ts
@@ -179,7 +179,7 @@ export class ComputeSessionClient {
             if (createBody) {
                 request.body = createBody
             }
-            const query = this.options.pop ? 'wait=true&transient=true' : 'wait=true'
+            const query = 'wait=true&transient=true'
             const response = await this.options.httpClient.fetch(`${sessionsUrl}?${query}`, request)
             if (response.status != 200) {
                 const message = await response.text()

--- a/src/eyepop/compute/compute_session.ts
+++ b/src/eyepop/compute/compute_session.ts
@@ -1,0 +1,268 @@
+import type { HttpClient } from '../options'
+import type { Pop } from '../worker/worker_types'
+
+export enum SessionStatus {
+    UNKNOWN = 'unknown',
+    PENDING = 'pending',
+    RUNNING = 'running',
+    STOPPED = 'stopped',
+    FAILED = 'failed',
+    ERROR = 'error',
+
+    PIPELINE_CREATING = 'pipeline_creating',
+    PIPELINE_OK = 'pipeline_ok',
+    PIPELINE_CHECKING = 'pipeline_checking',
+    PIPELINE_ERROR = 'pipeline_error',
+    UPGRADING = 'upgrading',
+}
+
+export interface ComputeSession {
+    session_uuid: string
+    session_endpoint: string
+    pipeline_uuid: string
+    access_token?: string
+    access_token_expires_at?: string
+    access_token_expires_in?: number
+    session_status: SessionStatus
+    session_message: string
+    session_name: string
+    user_uuid: string
+    created_at: string
+    uptime: number
+    pipeline_ttl?: number | undefined
+    session_active: boolean
+    persistent?: boolean
+    pipelines?: { id?: string; pipeline_id?: string }[]
+}
+
+export interface ResolvedComputeSession {
+    session: ComputeSession
+    pipelineId: string | null
+    accessToken: string
+    accessTokenValidUntil: number | null
+}
+
+export interface ComputeSessionClientOptions {
+    computeUrl: string
+    httpClient: HttpClient
+    authorizationHeader: () => Promise<string>
+    sessionUuid?: string | undefined
+    sessionName?: string | undefined
+    pipelineImage?: string | undefined
+    pipelineVersion?: string | undefined
+    pop?: Pop | undefined
+    readyTimeoutMs: number
+    logger?: Pick<Console, 'debug'>
+    requestLogger?: Pick<Console, 'debug'>
+}
+
+const SESSION_DEAD = new Set<SessionStatus>([SessionStatus.ERROR, SessionStatus.FAILED, SessionStatus.STOPPED, SessionStatus.PIPELINE_ERROR, SessionStatus.UNKNOWN])
+
+const CHECK_FOR_IS_READY_INTERVAL = 250
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+export function pipelineIdFromSession(session: ComputeSession): string | null {
+    if (session.pipeline_uuid) {
+        return session.pipeline_uuid
+    }
+    const pipeline = session.pipelines?.[0]
+    return pipeline?.id || pipeline?.pipeline_id || null
+}
+
+function sessionCreateBody(options: ComputeSessionClientOptions): string | undefined {
+    const body: any = {}
+    if (options.sessionName) {
+        body.session_name = options.sessionName
+    }
+    if (options.pipelineImage) {
+        body.pipeline_image = options.pipelineImage
+    }
+    if (options.pipelineVersion) {
+        body.pipeline_version = options.pipelineVersion
+    }
+    if (options.pop) {
+        body.pop = options.pop
+    }
+    return Object.keys(body).length > 0 ? JSON.stringify(body) : undefined
+}
+
+function sessionHealthReady(body: string, contentType: string): boolean {
+    if (contentType.includes('application/json')) {
+        const health = JSON.parse(body)
+        if (health && typeof health == 'object') {
+            if (health.message && !health.session_status) {
+                return true
+            }
+            return health.session_status == SessionStatus.RUNNING
+        }
+    }
+    return contentType.includes('text/plain') && body.includes("I'm fine")
+}
+
+function accessTokenValidUntil(session: ComputeSession): number | null {
+    if (session.access_token_expires_at) {
+        const expiresAt = Date.parse(session.access_token_expires_at)
+        return Number.isNaN(expiresAt) ? null : expiresAt
+    }
+    if (session.access_token_expires_in) {
+        return Date.now() + session.access_token_expires_in * 1000
+    }
+    return null
+}
+
+export class ComputeSessionClient {
+    constructor(private readonly options: ComputeSessionClientOptions) {}
+
+    public async resolve(): Promise<ResolvedComputeSession> {
+        const session = this.options.sessionUuid ? await this.getPermanentComputeSession(this.options.sessionUuid) : await this.getOnDemandComputeSession()
+        const accessToken = this.sessionAccessToken(session)
+        await this.waitUntilReady(session, accessToken)
+        const pipelineId = pipelineIdFromSession(session)
+        if (this.options.pop && !pipelineId) {
+            throw new Error('Compute session did not provide a pipeline for the requested pop')
+        }
+        return {
+            session,
+            pipelineId,
+            accessToken,
+            accessTokenValidUntil: accessTokenValidUntil(session),
+        }
+    }
+
+    private async getOnDemandComputeSession(): Promise<ComputeSession> {
+        let session: ComputeSession | null = null
+
+        const sessionsUrl = `${this.options.computeUrl}/v1/sessions`
+        const headers = {
+            Authorization: await this.options.authorizationHeader(),
+        }
+        let sessions: ComputeSession[]
+
+        if (!this.options.pop) {
+            this.options.requestLogger?.debug('fetching sessions from: %s', sessionsUrl)
+            const response = await this.options.httpClient.fetch(sessionsUrl, {
+                headers: headers,
+            })
+
+            if (response.status == 404) {
+                sessions = []
+            } else if (response.status != 200) {
+                const message = await response.text()
+                throw new Error(`Unexpected status ${response.status} fetching compute sessions: ${message}`)
+            } else {
+                const response_content = await response.json()
+                sessions = response_content as ComputeSession[]
+            }
+            if (sessions.length > 0) {
+                this.options.logger?.debug(`User has ${sessions.length} sessions, inspecting for usable session`)
+                for (let s of sessions) {
+                    if (!SESSION_DEAD.has(s.session_status) && !s.persistent && (!this.options.sessionName || s.session_name === this.options.sessionName)) {
+                        session = s
+                        this.options.logger?.debug(`Use active session ${s.session_uuid} with pipeline ${pipelineIdFromSession(s)}`)
+                        break
+                    }
+                }
+            }
+        }
+        if (!session) {
+            this.options.requestLogger?.debug('creating a new session at: %s', sessionsUrl)
+            const createBody = sessionCreateBody(this.options)
+            const createHeaders = {
+                ...headers,
+                ...(createBody ? { 'Content-Type': 'application/json' } : {}),
+            }
+            const request: RequestInit = {
+                headers: createHeaders,
+                method: 'POST',
+            }
+            if (createBody) {
+                request.body = createBody
+            }
+            const query = this.options.pop ? 'wait=true&transient=true' : 'wait=true'
+            const response = await this.options.httpClient.fetch(`${sessionsUrl}?${query}`, request)
+            if (response.status != 200) {
+                const message = await response.text()
+                throw new Error(`Unexpected status ${response.status} creating a compute session: ${message}`)
+            } else {
+                sessions = (await response.json()) as ComputeSession[]
+            }
+            if (sessions.length == 0) {
+                throw new Error('Unexpected, no compute session after attempt to create one')
+            }
+            session = sessions[0] || null
+        }
+        if (!session) {
+            throw new Error('unexpected undefined session')
+        }
+        if (this.options.pop && !pipelineIdFromSession(session)) {
+            throw new Error('Compute session did not provide a pipeline for the requested pop')
+        }
+        return session
+    }
+
+    private async getPermanentComputeSession(sessionUuid: string): Promise<ComputeSession> {
+        let session: ComputeSession | null = null
+
+        const sessionUrl = `${this.options.computeUrl}/v1/sessions/${sessionUuid}`
+        this.options.requestLogger?.debug('fetching session from: %s', sessionUrl)
+        const headers = {
+            Authorization: await this.options.authorizationHeader(),
+        }
+        let response = await this.options.httpClient.fetch(sessionUrl, {
+            headers: headers,
+        })
+        if (response.status == 404) {
+            throw new Error(`Unexpected status ${response.status} compute sessions ${sessionUuid} not found`)
+        } else if (response.status != 200) {
+            const message = await response.text()
+            throw new Error(`Unexpected status ${response.status} fetching compute sessions: ${message}`)
+        } else {
+            const response_content = await response.json()
+            session = response_content as ComputeSession
+        }
+        return session
+    }
+
+    private sessionAccessToken(session: ComputeSession): string {
+        if (!session.access_token) {
+            throw new Error(`Compute session ${session.session_uuid} did not provide an access token`)
+        }
+        return session.access_token
+    }
+
+    private async waitUntilReady(session: ComputeSession, accessToken: string): Promise<void> {
+        let isReady: boolean = false
+        const deadline: number = Date.now() + this.options.readyTimeoutMs
+        while (!isReady) {
+            const health_url = `${session.session_endpoint}/health`
+            const response = await this.options.httpClient.fetch(health_url, {
+                headers: {
+                    Authorization: `Bearer ${accessToken}`,
+                    Accept: 'application/json',
+                },
+            })
+            if (response.status == 200) {
+                const contentType = response.headers.get('content-type') || ''
+                const body = await response.text()
+                try {
+                    isReady = sessionHealthReady(body, contentType)
+                } catch (error) {
+                    this.options.logger?.debug(`session ${session.session_uuid} health check returned invalid JSON, wait and poll for update`)
+                }
+                if (!isReady && Date.now() > deadline) {
+                    throw new Error(`Created session ${session.session_uuid} did not become healthy after ${this.options.readyTimeoutMs / 1000} seconds`)
+                }
+                if (!isReady) {
+                    this.options.logger?.debug(`session ${session.session_uuid} health check not ready, wait and poll for update`)
+                    await sleep(CHECK_FOR_IS_READY_INTERVAL)
+                }
+            } else if (Date.now() > deadline) {
+                throw new Error(`Created session ${session.session_uuid} did not become healthy after ${this.options.readyTimeoutMs / 1000} seconds`)
+            } else {
+                this.options.logger?.debug(`session ${session.session_uuid} health check status ${response.status}, wait and poll for update`)
+                await sleep(CHECK_FOR_IS_READY_INTERVAL)
+            }
+        }
+    }
+}

--- a/src/eyepop/worker/worker_endpoint.ts
+++ b/src/eyepop/worker/worker_endpoint.ts
@@ -1,4 +1,6 @@
-import { ApiKeyAuth, HttpClient, LocalAuth } from '../options'
+import { ApiKeyAuth, LocalAuth } from '../options'
+import { ComputeSessionClient } from '../compute/compute_session'
+import type { ResolvedComputeSession } from '../compute/compute_session'
 import { EndpointState, Session } from '../types'
 import { AbstractJob, LoadFromAssetUuidJob, LoadFromJob, LoadMediaStreamJob, UploadJob } from './jobs'
 import { resolvePath } from '../shims/local_file'
@@ -34,42 +36,6 @@ interface Pipeline {
     state: string
     pop?: Pop
 }
-
-export enum SessionStatus {
-    UNKNOWN = 'unknown',
-    PENDING = 'pending',
-    RUNNING = 'running',
-    STOPPED = 'stopped',
-    FAILED = 'failed',
-    ERROR = 'error',
-
-    PIPELINE_CREATING = 'pipeline_creating',
-    PIPELINE_OK = 'pipeline_ok',
-    PIPELINE_CHECKING = 'pipeline_checking',
-    PIPELINE_ERROR = 'pipeline_error',
-    UPGRADING = 'upgrading',
-}
-
-interface ComputeSession {
-    session_uuid: string
-    session_endpoint: string
-    pipeline_uuid: string
-    access_token?: string
-    access_token_expires_at?: string
-    access_token_expires_in?: number
-    session_status: SessionStatus
-    session_message: string
-    session_name: string
-    user_uuid: string
-    created_at: string
-    uptime: number
-    pipeline_ttl?: number | undefined
-    session_active: boolean
-    persistent?: boolean
-    pipelines?: { id?: string; pipeline_id?: string }[]
-}
-
-const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 
 export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
     private _baseUrl: string | null
@@ -616,185 +582,44 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
         }
     }
 
-    private static SESSION_DEAD = new Set<SessionStatus>([SessionStatus.ERROR, SessionStatus.FAILED, SessionStatus.STOPPED, SessionStatus.PIPELINE_ERROR, SessionStatus.UNKNOWN])
-
     private static WAIT_FOR_IS_READY: number = 60 * 1000
-    private static CHECK_FOR_IS_READY_INTERVAL: number = 250
 
     private sessionReadyTimeoutMs(): number {
         const seconds = this.options().sessionReadyTimeoutSeconds
         return typeof seconds == 'number' && Number.isFinite(seconds) && seconds > 0 ? seconds * 1000 : WorkerEndpoint.WAIT_FOR_IS_READY
     }
 
-    private sessionHealthReady(body: string, contentType: string): boolean {
-        if (contentType.includes('application/json')) {
-            const health = JSON.parse(body)
-            if (health && typeof health == 'object') {
-                if (health.message && !health.session_status) {
-                    return true
-                }
-                return health.session_status == SessionStatus.RUNNING
-            }
-        }
-        return contentType.includes('text/plain') && body.includes("I'm fine")
-    }
-
     private async getComputeSession(): Promise<void> {
         if (!this._client) {
             throw new Error('endpoint not initialized')
         }
-        let session: ComputeSession
-        const sessionUuid = this.options().sessionUuid
-        if (sessionUuid) {
-            session = await this.getPermanentComputeSession(this._client, sessionUuid)
-        } else {
-            session = await this.getOnDemandComputeSession(this._client)
+        let resolved: ResolvedComputeSession
+        try {
+            resolved = await new ComputeSessionClient({
+                computeUrl: this.eyepopUrl(),
+                httpClient: this._client,
+                authorizationHeader: () => this.computeAuthorizationHeader(),
+                sessionUuid: this.options().sessionUuid,
+                sessionName: this.options().sessionName,
+                pipelineImage: this.options().pipelineImage,
+                pipelineVersion: this.options().pipelineVersion,
+                pop: this.options().pop,
+                readyTimeoutMs: this.sessionReadyTimeoutMs(),
+                logger: this._logger,
+                requestLogger: this._requestLogger,
+            }).resolve()
+        } catch (error) {
+            this.updateState(EndpointState.Error)
+            throw error
         }
-        this.setComputeSessionAccessToken(session)
-        const headers = {
-            Authorization: await this.authorizationHeader(),
-        }
-        let isReady: boolean = false
-        const readyTimeoutMs = this.sessionReadyTimeoutMs()
-        const deadline: number = Date.now() + readyTimeoutMs
-        while (!isReady) {
-            const health_url = `${session.session_endpoint}/health`
-            const response = await this._client.fetch(health_url, {
-                headers: {
-                    ...headers,
-                    Accept: 'application/json',
-                },
-            })
-            if (response.status == 200) {
-                const contentType = response.headers.get('content-type') || ''
-                const body = await response.text()
-                try {
-                    isReady = this.sessionHealthReady(body, contentType)
-                } catch (error) {
-                    this._logger.debug(`session ${session.session_uuid} health check returned invalid JSON, wait and poll for update`)
-                }
-                if (!isReady && Date.now() > deadline) {
-                    throw new Error(`Created session ${session.session_uuid} did not become healthy after ${readyTimeoutMs / 1000} seconds`)
-                }
-                if (!isReady) {
-                    this._logger.debug(`session ${session.session_uuid} health check not ready, wait and poll for update`)
-                    await sleep(WorkerEndpoint.CHECK_FOR_IS_READY_INTERVAL)
-                }
-            } else if (Date.now() > deadline) {
-                throw new Error(`Created session ${session.session_uuid} did not become healthy after ${readyTimeoutMs / 1000} seconds`)
-            } else {
-                this._logger.debug(`session ${session.session_uuid} health check status ${response.status}, wait and poll for update`)
-                await sleep(WorkerEndpoint.CHECK_FOR_IS_READY_INTERVAL)
-            }
-        }
-        this._baseUrl = session.session_endpoint
+        this._sessionAccessToken = resolved.accessToken
+        this._sessionAccessTokenValidUntil = resolved.accessTokenValidUntil
+        this._baseUrl = resolved.session.session_endpoint
         this._pipeline = null
-        this._pipelineId = this.pipelineIdFromSession(session)
+        this._pipelineId = resolved.pipelineId
         if (this.options().pop) {
             this.setTransientPipelinePop()
         }
-    }
-
-    private async getOnDemandComputeSession(httpClient: HttpClient): Promise<ComputeSession> {
-        let session: ComputeSession | null = null
-
-        const sessionsUrl = `${this.eyepopUrl()}/v1/sessions`
-        const headers = {
-            Authorization: await this.computeAuthorizationHeader(),
-        }
-        let sessions: ComputeSession[]
-
-        if (!this.options().pop) {
-            this._requestLogger.debug('fetching sessions from: %s', sessionsUrl)
-            const response = await httpClient.fetch(sessionsUrl, {
-                headers: headers,
-            })
-
-            if (response.status == 404) {
-                sessions = []
-            } else if (response.status != 200) {
-                this.updateState(EndpointState.Error)
-                const message = await response.text()
-                throw new Error(`Unexpected status ${response.status} fetching compute sessions: ${message}`)
-            } else {
-                const response_content = await response.json()
-                sessions = response_content as ComputeSession[]
-            }
-            if (sessions.length > 0) {
-                this._logger.debug(`User has ${sessions.length} sessions, inspecting for usable session`)
-                for (let s of sessions) {
-                    if (
-                        !WorkerEndpoint.SESSION_DEAD.has(s.session_status) &&
-                        !s.persistent &&
-                        (!this.options().sessionName || s.session_name === this.options().sessionName)
-                    ) {
-                        session = s
-                        this._logger.debug(`Use active session ${s.session_uuid} with pipeline ${this.pipelineIdFromSession(s)}`)
-                        break
-                    }
-                }
-            }
-        }
-        if (!session) {
-            this._requestLogger.debug('creating a new session at: %s', sessionsUrl)
-            const createBody = this.sessionCreateBody()
-            const createHeaders = {
-                ...headers,
-                ...(createBody ? { 'Content-Type': 'application/json' } : {}),
-            }
-            const request: RequestInit = {
-                headers: createHeaders,
-                method: 'POST',
-            }
-            if (createBody) {
-                request.body = createBody
-            }
-            const query = this.options().pop ? 'wait=true&transient=true' : 'wait=true'
-            const response = await httpClient.fetch(`${sessionsUrl}?${query}`, request)
-            if (response.status != 200) {
-                this.updateState(EndpointState.Error)
-                const message = await response.text()
-                throw new Error(`Unexpected status ${response.status} creating a compute session: ${message}`)
-            } else {
-                sessions = (await response.json()) as ComputeSession[]
-            }
-            if (sessions.length == 0) {
-                throw new Error('Unexpected, no compute session after attempt to create one')
-            }
-            session = sessions[0] || null
-        }
-        if (!session) {
-            throw new Error('unexpected undefined session')
-        }
-        if (this.options().pop && !this.pipelineIdFromSession(session)) {
-            throw new Error('Compute session did not provide a pipeline for the requested pop')
-        }
-        return session
-    }
-
-    private async getPermanentComputeSession(httpClient: HttpClient, sessionUuid: string): Promise<ComputeSession> {
-        let session: ComputeSession | null = null
-
-        const sessionUrl = `${this.eyepopUrl()}/v1/sessions/${sessionUuid}`
-        this._requestLogger.debug('fetching session from: %s', sessionUrl)
-        const headers = {
-            Authorization: await this.computeAuthorizationHeader(),
-        }
-        let response = await httpClient.fetch(sessionUrl, {
-            headers: headers,
-        })
-        if (response.status == 404) {
-            this.updateState(EndpointState.Error)
-            throw new Error(`Unexpected status ${response.status} compute sessions ${sessionUuid} not found`)
-        } else if (response.status != 200) {
-            this.updateState(EndpointState.Error)
-            const message = await response.text()
-            throw new Error(`Unexpected status ${response.status} fetching compute sessions: ${message}`)
-        } else {
-            const response_content = await response.json()
-            session = response_content as ComputeSession
-        }
-        return session
     }
 
     private async startTransientPipeline(): Promise<string> {
@@ -859,6 +684,13 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
         if (this._pipelineId) {
             return
         }
+        if (this.options().pop) {
+            await this.reconnect()
+            if (!this._pipelineId) {
+                throw new Error('Compute session did not provide a pipeline for the requested pop')
+            }
+            return
+        }
         if (!this._pipelineCreatePromise) {
             this._pipelineCreatePromise = this.startTransientPipeline()
         }
@@ -890,7 +722,7 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
             this.options().pop = previousPop
             this._pipeline = null
             this._pipelineId = null
-            this._baseUrl = previousBaseUrl
+            this._baseUrl = previousPop ? null : previousBaseUrl
             this._sessionAccessToken = previousSessionAccessToken
             this._sessionAccessTokenValidUntil = previousSessionAccessTokenValidUntil
             throw error
@@ -919,14 +751,6 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
         }
     }
 
-    private pipelineIdFromSession(session: ComputeSession): string | null {
-        if (session.pipeline_uuid) {
-            return session.pipeline_uuid
-        }
-        const pipeline = session.pipelines?.[0]
-        return pipeline?.id || pipeline?.pipeline_id || null
-    }
-
     protected override async authorizationHeader(): Promise<string> {
         if (this._sessionAccessToken) {
             return `Bearer ${this._sessionAccessToken}`
@@ -944,21 +768,6 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
         return super.authorizationHeader()
     }
 
-    private setComputeSessionAccessToken(session: ComputeSession): void {
-        if (!session.access_token) {
-            throw new Error(`Compute session ${session.session_uuid} did not provide an access token`)
-        }
-        this._sessionAccessToken = session.access_token
-        if (session.access_token_expires_at) {
-            const expiresAt = Date.parse(session.access_token_expires_at)
-            this._sessionAccessTokenValidUntil = Number.isNaN(expiresAt) ? null : expiresAt
-        } else if (session.access_token_expires_in) {
-            this._sessionAccessTokenValidUntil = Date.now() + session.access_token_expires_in * 1000
-        } else {
-            this._sessionAccessTokenValidUntil = null
-        }
-    }
-
     private setTransientPipelinePop(): void {
         const pop = this.options().pop
         if (pop && this._pipelineId) {
@@ -971,20 +780,4 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
         }
     }
 
-    private sessionCreateBody(): string | undefined {
-        const body: any = {}
-        if (this.options().sessionName) {
-            body.session_name = this.options().sessionName
-        }
-        if (this.options().pipelineImage) {
-            body.pipeline_image = this.options().pipelineImage
-        }
-        if (this.options().pipelineVersion) {
-            body.pipeline_version = this.options().pipelineVersion
-        }
-        if (this.options().pop) {
-            body.pop = this.options().pop
-        }
-        return Object.keys(body).length > 0 ? JSON.stringify(body) : undefined
-    }
 }

--- a/src/eyepop/worker/worker_endpoint.ts
+++ b/src/eyepop/worker/worker_endpoint.ts
@@ -723,7 +723,11 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
             if (sessions.length > 0) {
                 this._logger.debug(`User has ${sessions.length} sessions, inspecting for usable session`)
                 for (let s of sessions) {
-                    if (!WorkerEndpoint.SESSION_DEAD.has(s.session_status) && !s.persistent) {
+                    if (
+                        !WorkerEndpoint.SESSION_DEAD.has(s.session_status) &&
+                        !s.persistent &&
+                        (!this.options().sessionName || s.session_name === this.options().sessionName)
+                    ) {
                         session = s
                         this._logger.debug(`Use active session ${s.session_uuid} with pipeline ${this.pipelineIdFromSession(s)}`)
                         break
@@ -871,9 +875,9 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
             throw new Error('endpoint not initialized')
         }
         const previousPop = this.options().pop
-        const previousPipeline = this._pipeline
-        const previousPipelineId = this._pipelineId
         const previousBaseUrl = this._baseUrl
+        const previousSessionAccessToken = this._sessionAccessToken
+        const previousSessionAccessTokenValidUntil = this._sessionAccessTokenValidUntil
         if (this._pipelineId) {
             await this.deleteTransientPipeline(this._pipelineId)
             this._pipelineId = null
@@ -884,9 +888,11 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
             await this.getComputeSession()
         } catch (error) {
             this.options().pop = previousPop
-            this._pipeline = previousPipeline
-            this._pipelineId = previousPipelineId
+            this._pipeline = null
+            this._pipelineId = null
             this._baseUrl = previousBaseUrl
+            this._sessionAccessToken = previousSessionAccessToken
+            this._sessionAccessTokenValidUntil = previousSessionAccessTokenValidUntil
             throw error
         }
         if (!this._pipelineId) {

--- a/src/eyepop/worker/worker_endpoint.ts
+++ b/src/eyepop/worker/worker_endpoint.ts
@@ -745,7 +745,8 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
             if (createBody) {
                 request.body = createBody
             }
-            const response = await httpClient.fetch(`${sessionsUrl}?wait=true`, request)
+            const query = this.options().pop ? 'wait=true&transient=true' : 'wait=true'
+            const response = await httpClient.fetch(`${sessionsUrl}?${query}`, request)
             if (response.status != 200) {
                 this.updateState(EndpointState.Error)
                 const message = await response.text()
@@ -760,6 +761,9 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
         }
         if (!session) {
             throw new Error('unexpected undefined session')
+        }
+        if (this.options().pop && !this.pipelineIdFromSession(session)) {
+            throw new Error('Compute session did not provide a pipeline for the requested pop')
         }
         return session
     }
@@ -868,6 +872,8 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
         }
         const previousPop = this.options().pop
         const previousPipeline = this._pipeline
+        const previousPipelineId = this._pipelineId
+        const previousBaseUrl = this._baseUrl
         if (this._pipelineId) {
             await this.deleteTransientPipeline(this._pipelineId)
             this._pipelineId = null
@@ -875,10 +881,12 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
         this._pipeline = null
         try {
             this.options().pop = pop
-            await this.ensureTransientPipelineStarted()
+            await this.getComputeSession()
         } catch (error) {
             this.options().pop = previousPop
             this._pipeline = previousPipeline
+            this._pipelineId = previousPipelineId
+            this._baseUrl = previousBaseUrl
             throw error
         }
         if (!this._pipelineId) {

--- a/src/react-native-eyepop/README.md
+++ b/src/react-native-eyepop/README.md
@@ -24,7 +24,7 @@ Theses are all the dependencies to add to the application's `package.json`:
 ```json
 {
   "dependencies": {
-    "@eyepop.ai/react-native-eyepop": "1.15.1",
+    "@eyepop.ai/react-native-eyepop": "3.16.0",
     "react-native-canvas": "^0.1.40",
     "react-native-file-access": "^3.1.1",
     "react-native-polyfill-globals": "^3.1.0",
@@ -35,9 +35,9 @@ Theses are all the dependencies to add to the application's `package.json`:
 }
 ```
 
-Use the `EyePop` namespace from `react-native-eyepop` with the identical Api as the original `eyepop` package.
+Use the `EyePop` namespace from `@eyepop.ai/react-native-eyepop` with the identical API as the original `@eyepop.ai/eyepop` package, including `WorkerOptions.pop` for transient ModelLess sessions and `WorkerOptions.sessionUuid` for persistent sessions.
 ```js
-import { EyePop } from 'react-native-eyepop';
+import { EyePop } from '@eyepop.ai/react-native-eyepop';
 
 const endpoint = EyePop.workerEndpoint({
     auth: { session },

--- a/src/react-native-eyepop/package.json
+++ b/src/react-native-eyepop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eyepop.ai/react-native-eyepop",
-  "version": "3.15.1",
+  "version": "3.16.0",
   "description": "The official Typescript library for EyePop.ai's inference API for React Native",
   "source": "./src/index.ts",
   "main": "./lib/commonjs/index.js",
@@ -68,8 +68,8 @@
   },
   "dependencies": {
       "@azure/core-asynciterator-polyfill": "^1.0.2",
-      "@eyepop.ai/eyepop": "3.15.1",
-      "@eyepop.ai/eyepop-render-2d": "3.15.1",
+      "@eyepop.ai/eyepop": "3.16.0",
+      "@eyepop.ai/eyepop-render-2d": "3.16.0",
       "@types/react-native-canvas": "^0.1.14",
       "buffer": "^6.0.3",
       "react": "^19.2.0",

--- a/tests/eyepop/compute/compute_session.test.ts
+++ b/tests/eyepop/compute/compute_session.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from '@jest/globals'
+
+import { ComputeSessionClient, SessionStatus } from '../../../src/eyepop/compute/compute_session'
+import type { HttpClient } from '../../../src/eyepop/options'
+import { PopComponentType, type Pop } from '../../../src/eyepop'
+
+const computeUrl = 'https://compute.example.test'
+const sessionEndpoint = 'https://worker.example.test/session'
+const accessToken = 'session-token'
+
+function sessionResponse(pipelineId?: string) {
+    return [
+        {
+            session_uuid: 'session-uuid',
+            session_endpoint: sessionEndpoint,
+            pipeline_uuid: pipelineId || '',
+            access_token: accessToken,
+            access_token_expires_in: 60,
+            session_status: SessionStatus.RUNNING,
+            session_message: '',
+            session_name: 'node-sdk-test',
+            user_uuid: 'user-uuid',
+            created_at: new Date(0).toISOString(),
+            uptime: 0,
+            session_active: true,
+            persistent: false,
+            pipelines: pipelineId ? [{ pipeline_id: pipelineId }] : [],
+        },
+    ]
+}
+
+type FetchCall = { url: string; init: RequestInit | undefined }
+
+function createHttpClient(calls: FetchCall[], pipelineId?: string): HttpClient {
+    return {
+        async fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+            const url = input.toString()
+            calls.push({ url, init })
+            if (url === `${computeUrl}/v1/sessions`) {
+                return new Response('not found', { status: 404 })
+            }
+            if (url.startsWith(`${computeUrl}/v1/sessions?`)) {
+                return new Response(JSON.stringify(sessionResponse(pipelineId)), {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                })
+            }
+            if (url === `${sessionEndpoint}/health`) {
+                return new Response("I'm fine", {
+                    status: 200,
+                    headers: { 'content-type': 'text/plain' },
+                })
+            }
+            return new Response(`unexpected url ${url}`, { status: 500 })
+        },
+        async close(): Promise<void> {},
+        isFullDuplex(): boolean {
+            return false
+        },
+    }
+}
+
+describe('ComputeSessionClient', () => {
+    const authorizationHeader = async () => 'Bearer api-key'
+    const readyTimeoutMs = 1000
+
+    test('creates no-pop on-demand sessions as transient sessions', async () => {
+        const calls: FetchCall[] = []
+
+        await new ComputeSessionClient({
+            computeUrl,
+            httpClient: createHttpClient(calls),
+            authorizationHeader,
+            readyTimeoutMs,
+        }).resolve()
+
+        const createCall = calls.find(call => call.init?.method === 'POST')
+        expect(createCall?.url).toBe(`${computeUrl}/v1/sessions?wait=true&transient=true`)
+    })
+
+    test('creates constructor-pop sessions as transient sessions', async () => {
+        const calls: FetchCall[] = []
+        const pop: Pop = {
+            components: [
+                {
+                    type: PopComponentType.INFERENCE,
+                    ability: 'eyepop.localize-objects:latest',
+                    categoryName: 'objects',
+                    params: { prompts: [{ prompt: 'person' }] },
+                },
+            ],
+        }
+
+        await new ComputeSessionClient({
+            computeUrl,
+            httpClient: createHttpClient(calls, 'pipeline-uuid'),
+            authorizationHeader,
+            readyTimeoutMs,
+            pop,
+        }).resolve()
+
+        const createCall = calls.find(call => call.init?.method === 'POST')
+        expect(createCall?.url).toBe(`${computeUrl}/v1/sessions?wait=true&transient=true`)
+        expect(JSON.parse(String(createCall?.init?.body))).toEqual({ pop })
+    })
+})

--- a/tests/eyepop/compute/compute_session.test.ts
+++ b/tests/eyepop/compute/compute_session.test.ts
@@ -64,7 +64,7 @@ describe('ComputeSessionClient', () => {
     const authorizationHeader = async () => 'Bearer api-key'
     const readyTimeoutMs = 1000
 
-    test('creates no-pop on-demand sessions as transient sessions', async () => {
+    test('creates no-pop on-demand sessions with wait', async () => {
         const calls: FetchCall[] = []
 
         await new ComputeSessionClient({
@@ -75,10 +75,10 @@ describe('ComputeSessionClient', () => {
         }).resolve()
 
         const createCall = calls.find(call => call.init?.method === 'POST')
-        expect(createCall?.url).toBe(`${computeUrl}/v1/sessions?wait=true&transient=true`)
+        expect(createCall?.url).toBe(`${computeUrl}/v1/sessions?wait=true`)
     })
 
-    test('creates constructor-pop sessions as transient sessions', async () => {
+    test('creates constructor-pop sessions with wait', async () => {
         const calls: FetchCall[] = []
         const pop: Pop = {
             components: [
@@ -100,7 +100,7 @@ describe('ComputeSessionClient', () => {
         }).resolve()
 
         const createCall = calls.find(call => call.init?.method === 'POST')
-        expect(createCall?.url).toBe(`${computeUrl}/v1/sessions?wait=true&transient=true`)
+        expect(createCall?.url).toBe(`${computeUrl}/v1/sessions?wait=true`)
         expect(JSON.parse(String(createCall?.init?.body))).toEqual({ pop })
     })
 })

--- a/tests/eyepop/worker/endpoint.connect.transient.test.ts
+++ b/tests/eyepop/worker/endpoint.connect.transient.test.ts
@@ -293,6 +293,193 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
         }
     })
 
+    test('EyePopSdk changePop transient clears deleted pipeline and restores token when replacement session fails', async () => {
+        const initialSessionUuid = uuidv4().toString()
+        const replacementSessionUuid = uuidv4().toString()
+        const initialPipelineId = uuidv4()
+        const replacementPipelineId = uuidv4()
+        const initialAccessToken = uuidv4()
+        const replacementAccessToken = uuidv4()
+        const replacementPop: Pop = {
+            components: [
+                {
+                    type: PopComponentType.INFERENCE,
+                    ability: 'eyepop.person:latest',
+                    categoryName: 'person',
+                },
+            ],
+        }
+
+        server.post('/v1/auth/authenticate').mockImplementationOnce(ctx => {
+            ctx.status = 200
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify({
+                access_token: test_access_token,
+                expires_in: long_token_valid_time,
+                token_type: 'Bearer',
+            })
+        })
+
+        const createSessionRoute = server
+            .post(`/v1/sessions`)
+            .mockImplementationOnce(ctx => {
+                ctx.status = 200
+                ctx.response.headers['content-type'] = 'application/json'
+                ctx.body = JSON.stringify([
+                    {
+                        session_uuid: initialSessionUuid,
+                        session_endpoint: `${server.getURL().toString()}${initialSessionUuid}`,
+                        access_token: initialAccessToken,
+                        access_token_expires_in: long_token_valid_time,
+                        pipeline_uuid: initialPipelineId,
+                        session_status: 'running',
+                        session_active: true,
+                    },
+                ])
+            })
+            .mockImplementationOnce(ctx => {
+                ctx.status = 200
+                ctx.response.headers['content-type'] = 'application/json'
+                ctx.body = JSON.stringify([
+                    {
+                        session_uuid: replacementSessionUuid,
+                        session_endpoint: `${server.getURL().toString()}${replacementSessionUuid}`,
+                        access_token: replacementAccessToken,
+                        access_token_expires_in: long_token_valid_time,
+                        pipeline_uuid: replacementPipelineId,
+                        session_status: 'pipeline_creating',
+                        session_active: true,
+                    },
+                ])
+            })
+
+        server.get(`/${initialSessionUuid}/health`).mockImplementation(ctx => {
+            ctx.status = 200
+            ctx.response.headers['content-type'] = 'text/plain'
+            ctx.body = "I'm fine"
+        })
+
+        const replacementHealthRoute = server.get(`/${replacementSessionUuid}/health`).mockImplementation(ctx => {
+            ctx.status = 200
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify({
+                session_status: 'pipeline_creating',
+            })
+        })
+
+        const deleteInitialPipelineRoute = server.delete(`/${initialSessionUuid}/pipelines/${initialPipelineId}`).mockImplementationOnce(ctx => {
+            ctx.status = 204
+        })
+
+        const endpoint = EyePop.workerEndpoint({
+            eyepopUrl: server.getURL().toString(),
+            popId: test_pop_id,
+            pop: test_transient_pop,
+            sessionReadyTimeoutSeconds: 0.001,
+            auth: { apiKey: test_api_key },
+        })
+
+        try {
+            await endpoint.connect()
+            expect((endpoint as any)._pipelineId).toEqual(initialPipelineId)
+            expect((endpoint as any)._sessionAccessToken).toEqual(initialAccessToken)
+
+            await expect(endpoint.changePop(replacementPop)).rejects.toThrow(
+                `Created session ${replacementSessionUuid} did not become healthy after 0.001 seconds`,
+            )
+
+            expect(endpoint.pop()).toEqual(test_transient_pop)
+            expect((endpoint as any)._baseUrl).toEqual(`${server.getURL().toString()}${initialSessionUuid}`)
+            expect((endpoint as any)._pipeline).toBeNull()
+            expect((endpoint as any)._pipelineId).toBeNull()
+            expect((endpoint as any)._sessionAccessToken).toEqual(initialAccessToken)
+            expect(deleteInitialPipelineRoute).toHaveBeenCalledTimes(1)
+            expect(createSessionRoute).toHaveBeenCalledTimes(2)
+            expect(replacementHealthRoute).toHaveBeenCalled()
+        } finally {
+            await endpoint.disconnect()
+        }
+    })
+
+    test('EyePopSdk only reuses a transient session with the configured session name', async () => {
+        const existingSessionUuid = uuidv4().toString()
+        const createdSessionUuid = uuidv4().toString()
+        const createdPipelineId = uuidv4()
+
+        server.post('/v1/auth/authenticate').mockImplementationOnce(ctx => {
+            ctx.status = 200
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify({
+                access_token: test_access_token,
+                expires_in: long_token_valid_time,
+                token_type: 'Bearer',
+            })
+        })
+
+        const listSessionsRoute = server.get(`/v1/sessions`).mockImplementationOnce(ctx => {
+            ctx.status = 200
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify([
+                {
+                    session_uuid: existingSessionUuid,
+                    session_endpoint: `${server.getURL().toString()}${existingSessionUuid}`,
+                    access_token: test_access_token,
+                    access_token_expires_in: long_token_valid_time,
+                    pipeline_uuid: uuidv4(),
+                    session_status: 'running',
+                    session_active: true,
+                    session_name: 'other-smoke-scenario',
+                    persistent: false,
+                },
+            ])
+        })
+
+        const createSessionRoute = server.post(`/v1/sessions`).mockImplementationOnce(ctx => {
+            ctx.status = 200
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify([
+                {
+                    session_uuid: createdSessionUuid,
+                    session_endpoint: `${server.getURL().toString()}${createdSessionUuid}`,
+                    access_token: test_access_token,
+                    access_token_expires_in: long_token_valid_time,
+                    pipeline_uuid: createdPipelineId,
+                    session_status: 'running',
+                    session_active: true,
+                    session_name: 'target-smoke-scenario',
+                    persistent: false,
+                },
+            ])
+        })
+
+        server.get(`/${createdSessionUuid}/health`).mockImplementation(ctx => {
+            ctx.status = 200
+            ctx.response.headers['content-type'] = 'text/plain'
+            ctx.body = "I'm fine"
+        })
+
+        server.delete(`/${createdSessionUuid}/pipelines/${createdPipelineId}`).mockImplementationOnce(ctx => {
+            ctx.status = 204
+        })
+
+        const endpoint = EyePop.workerEndpoint({
+            eyepopUrl: server.getURL().toString(),
+            popId: test_pop_id,
+            sessionName: 'target-smoke-scenario',
+            auth: { apiKey: test_api_key },
+        })
+
+        try {
+            await endpoint.connect()
+            const session = await endpoint.session()
+            expect(session.pipelineId).toEqual(createdPipelineId)
+            expect(listSessionsRoute).toHaveBeenCalledTimes(1)
+            expect(createSessionRoute).toHaveBeenCalledTimes(1)
+        } finally {
+            await endpoint.disconnect()
+        }
+    })
+
     test('EyePopSdk sends constructor pop to compute and uses returned transient pipeline', async () => {
         server.post('/v1/auth/authenticate').mockImplementationOnce(ctx => {
             ctx.status = 200

--- a/tests/eyepop/worker/endpoint.connect.transient.test.ts
+++ b/tests/eyepop/worker/endpoint.connect.transient.test.ts
@@ -298,6 +298,7 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
         const replacementSessionUuid = uuidv4().toString()
         const initialPipelineId = uuidv4()
         const replacementPipelineId = uuidv4()
+        const recoveryPipelineId = uuidv4()
         const initialAccessToken = uuidv4()
         const replacementAccessToken = uuidv4()
         const replacementPop: Pop = {
@@ -352,6 +353,21 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
                     },
                 ])
             })
+            .mockImplementationOnce(ctx => {
+                ctx.status = 200
+                ctx.response.headers['content-type'] = 'application/json'
+                ctx.body = JSON.stringify([
+                    {
+                        session_uuid: initialSessionUuid,
+                        session_endpoint: `${server.getURL().toString()}${initialSessionUuid}`,
+                        access_token: initialAccessToken,
+                        access_token_expires_in: long_token_valid_time,
+                        pipeline_uuid: recoveryPipelineId,
+                        session_status: 'running',
+                        session_active: true,
+                    },
+                ])
+            })
 
         server.get(`/${initialSessionUuid}/health`).mockImplementation(ctx => {
             ctx.status = 200
@@ -368,6 +384,24 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
         })
 
         const deleteInitialPipelineRoute = server.delete(`/${initialSessionUuid}/pipelines/${initialPipelineId}`).mockImplementationOnce(ctx => {
+            ctx.status = 204
+        })
+
+        const startPipelineRoute = server.post(`/${initialSessionUuid}/pipelines`).mockImplementationOnce(ctx => {
+            ctx.status = 200
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify({
+                id: uuidv4(),
+            })
+        })
+
+        const sourceRoute = server.patch(`/${initialSessionUuid}/pipelines/${recoveryPipelineId}/source`).mockImplementationOnce(ctx => {
+            ctx.status = 200
+            ctx.response.headers['content-type'] = 'application/jsonl'
+            ctx.body = JSON.stringify({ objects: [] }) + '\n'
+        })
+
+        server.delete(`/${initialSessionUuid}/pipelines/${recoveryPipelineId}`).mockImplementationOnce(ctx => {
             ctx.status = 204
         })
 
@@ -389,13 +423,26 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
             )
 
             expect(endpoint.pop()).toEqual(test_transient_pop)
-            expect((endpoint as any)._baseUrl).toEqual(`${server.getURL().toString()}${initialSessionUuid}`)
+            expect((endpoint as any)._baseUrl).toBeNull()
             expect((endpoint as any)._pipeline).toBeNull()
             expect((endpoint as any)._pipelineId).toBeNull()
             expect((endpoint as any)._sessionAccessToken).toEqual(initialAccessToken)
             expect(deleteInitialPipelineRoute).toHaveBeenCalledTimes(1)
             expect(createSessionRoute).toHaveBeenCalledTimes(2)
             expect(replacementHealthRoute).toHaveBeenCalled()
+
+            const stream = await endpoint.process({ source: { url: 'https://example.com/cat.jpg' } })
+            const predictions = []
+            for await (const prediction of stream) {
+                predictions.push(prediction)
+            }
+
+            expect(predictions).toHaveLength(1)
+            expect((endpoint as any)._baseUrl).toEqual(`${server.getURL().toString()}${initialSessionUuid}`)
+            expect((endpoint as any)._pipelineId).toEqual(recoveryPipelineId)
+            expect(createSessionRoute).toHaveBeenCalledTimes(3)
+            expect(startPipelineRoute).toHaveBeenCalledTimes(0)
+            expect(sourceRoute).toHaveBeenCalledTimes(1)
         } finally {
             await endpoint.disconnect()
         }

--- a/tests/eyepop/worker/endpoint.connect.transient.test.ts
+++ b/tests/eyepop/worker/endpoint.connect.transient.test.ts
@@ -109,7 +109,7 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
             ctx.body = JSON.stringify('no sessions')
         })
 
-        let pipelineCreatePop: Pop | null = null
+        let changePopCreateBody: any = null
         const createSessionRoute = server
             .post(`/v1/sessions`)
             .mockImplementationOnce(ctx => {
@@ -127,6 +127,22 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
                     },
                 ])
             })
+            .mockImplementationOnce(ctx => {
+                changePopCreateBody = (ctx.request as any).body
+                ctx.status = 200
+                ctx.response.headers['content-type'] = 'application/json'
+                ctx.body = JSON.stringify([
+                    {
+                        session_uuid: test_session_uuid,
+                        session_endpoint: `${server.getURL().toString()}${test_session_uuid}`,
+                        access_token: test_access_token,
+                        access_token_expires_in: long_token_valid_time,
+                        pipelines: [{ pipeline_id: test_pipeline_id }],
+                        session_status: 'running',
+                        session_active: true,
+                    },
+                ])
+            })
 
         const healthRoute = server.get(`/${test_session_uuid}/health`).mockImplementation(ctx => {
             ctx.status = 200
@@ -135,11 +151,10 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
         })
 
         const startPipelineRoute = server.post(`/${test_session_uuid}/pipelines`).mockImplementationOnce(ctx => {
-            pipelineCreatePop = (ctx.request.body as any)['pop']
             ctx.status = 200
             ctx.response.headers['content-type'] = 'application/json'
             ctx.body = JSON.stringify({
-                id: test_pipeline_id,
+                id: uuidv4(),
             })
         })
 
@@ -173,10 +188,10 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
             const session = await endpoint.session()
             expect(pop).toEqual(test_transient_pop)
             expect(session.pipelineId).toEqual(test_pipeline_id)
-            expect(pipelineCreatePop).toEqual(test_transient_pop)
+            expect(changePopCreateBody).toEqual({ pop: test_transient_pop })
             expect(stopInitialPipelineRoute).toHaveBeenCalledTimes(0)
-            expect(createSessionRoute).toHaveBeenCalledTimes(1)
-            expect(startPipelineRoute).toHaveBeenCalledTimes(1)
+            expect(createSessionRoute).toHaveBeenCalledTimes(2)
+            expect(startPipelineRoute).toHaveBeenCalledTimes(0)
             expect(patchPopRoute).toHaveBeenCalledTimes(0)
         } finally {
             await endpoint.disconnect()
@@ -201,21 +216,38 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
         })
 
         const replacementPipelineId = uuidv4()
-        const createSessionRoute = server.post(`/v1/sessions`).mockImplementationOnce(ctx => {
-            ctx.status = 200
-            ctx.response.headers['content-type'] = 'application/json'
-            ctx.body = JSON.stringify([
-                {
-                    session_uuid: test_session_uuid,
-                    session_endpoint: `${server.getURL().toString()}${test_session_uuid}`,
-                    access_token: test_access_token,
-                    access_token_expires_in: long_token_valid_time,
-                    pipeline_uuid: test_pipeline_id,
-                    session_status: 'running',
-                    session_active: true,
-                },
-            ])
-        })
+        const createSessionRoute = server
+            .post(`/v1/sessions`)
+            .mockImplementationOnce(ctx => {
+                ctx.status = 200
+                ctx.response.headers['content-type'] = 'application/json'
+                ctx.body = JSON.stringify([
+                    {
+                        session_uuid: test_session_uuid,
+                        session_endpoint: `${server.getURL().toString()}${test_session_uuid}`,
+                        access_token: test_access_token,
+                        access_token_expires_in: long_token_valid_time,
+                        pipeline_uuid: test_pipeline_id,
+                        session_status: 'running',
+                        session_active: true,
+                    },
+                ])
+            })
+            .mockImplementationOnce(ctx => {
+                ctx.status = 200
+                ctx.response.headers['content-type'] = 'application/json'
+                ctx.body = JSON.stringify([
+                    {
+                        session_uuid: test_session_uuid,
+                        session_endpoint: `${server.getURL().toString()}${test_session_uuid}`,
+                        access_token: test_access_token,
+                        access_token_expires_in: long_token_valid_time,
+                        pipeline_uuid: replacementPipelineId,
+                        session_status: 'running',
+                        session_active: true,
+                    },
+                ])
+            })
 
         server.get(`/${test_session_uuid}/health`).mockImplementation(ctx => {
             ctx.status = 200
@@ -254,8 +286,8 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
             expect(endpoint.pop()).toEqual(test_transient_pop)
             expect(session.pipelineId).toEqual(replacementPipelineId)
             expect(failedDeleteRoute).toHaveBeenCalledTimes(1)
-            expect(createSessionRoute).toHaveBeenCalledTimes(1)
-            expect(startPipelineRoute).toHaveBeenCalledTimes(1)
+            expect(createSessionRoute).toHaveBeenCalledTimes(2)
+            expect(startPipelineRoute).toHaveBeenCalledTimes(0)
         } finally {
             await endpoint.disconnect()
         }
@@ -377,7 +409,7 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
                     session_endpoint: `${server.getURL().toString()}${test_session_uuid}`,
                     access_token: test_access_token,
                     access_token_expires_in: long_token_valid_time,
-                    pipelines: [],
+                    pipelines: [{ pipeline_id: test_pipeline_id }],
                     session_status: 'pipeline_creating',
                     session_active: true,
                 },
@@ -404,7 +436,7 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
         expect(healthRoute).toHaveBeenCalled()
     })
 
-    test('EyePopSdk starts constructor pop pipeline before first source when compute returns no pipeline', async () => {
+    test('EyePopSdk rejects constructor pop when compute returns no pipeline', async () => {
         server.post('/v1/auth/authenticate').mockImplementationOnce(ctx => {
             ctx.status = 200
             ctx.response.headers['content-type'] = 'application/json'
@@ -463,16 +495,6 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
             })
         })
 
-        const stopRoute = server.delete(`/${test_session_uuid}/pipelines/${test_pipeline_id}`).mockImplementationOnce(ctx => {
-            ctx.status = 204
-        })
-
-        const sourceRoute = server.patch(`/${test_session_uuid}/pipelines/${test_pipeline_id}/source`).mockImplementationOnce(ctx => {
-            ctx.status = 200
-            ctx.response.headers['content-type'] = 'application/jsonl'
-            ctx.body = JSON.stringify({ objects: [] }) + '\n'
-        })
-
         const endpoint = EyePop.workerEndpoint({
             eyepopUrl: server.getURL().toString(),
             popId: test_pop_id,
@@ -480,30 +502,13 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
             auth: { apiKey: test_api_key },
         })
 
-        try {
-            await endpoint.connect()
-            const session = await endpoint.session()
-            expect(session.pipelineId).toBeUndefined()
-            expect(pollSessionRoute).toHaveBeenCalledTimes(0)
-            expect(listPipelinesRoute).toHaveBeenCalledTimes(0)
-            expect(startPipelineRoute).toHaveBeenCalledTimes(0)
-
-            const stream = await endpoint.process({ source: { url: 'https://example.com/cat.jpg' } })
-            const predictions = []
-            for await (const prediction of stream) {
-                predictions.push(prediction)
-            }
-
-            expect(predictions).toHaveLength(1)
-            expect(startPipelineRoute).toHaveBeenCalledTimes(1)
-            expect(sourceRoute).toHaveBeenCalledTimes(1)
-        } finally {
-            await endpoint.disconnect()
-            expect(stopRoute).toHaveBeenCalledTimes(1)
-        }
+        await expect(endpoint.connect()).rejects.toThrow('Compute session did not provide a pipeline for the requested pop')
+        expect(pollSessionRoute).toHaveBeenCalledTimes(0)
+        expect(listPipelinesRoute).toHaveBeenCalledTimes(0)
+        expect(startPipelineRoute).toHaveBeenCalledTimes(0)
     })
 
-    test('EyePopSdk does not poll compute detail when starting constructor pop pipeline', async () => {
+    test('EyePopSdk does not poll compute detail when compute returns no constructor pop pipeline', async () => {
         server.post('/v1/auth/authenticate').mockImplementationOnce(ctx => {
             ctx.status = 200
             ctx.response.headers['content-type'] = 'application/json'
@@ -567,16 +572,6 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
             })
         })
 
-        const stopRoute = server.delete(`/${test_session_uuid}/pipelines/${test_pipeline_id}`).mockImplementationOnce(ctx => {
-            ctx.status = 204
-        })
-
-        const sourceRoute = server.patch(`/${test_session_uuid}/pipelines/${test_pipeline_id}/source`).mockImplementationOnce(ctx => {
-            ctx.status = 200
-            ctx.response.headers['content-type'] = 'application/jsonl'
-            ctx.body = JSON.stringify({ objects: [] }) + '\n'
-        })
-
         const endpoint = EyePop.workerEndpoint({
             eyepopUrl: server.getURL().toString(),
             popId: test_pop_id,
@@ -584,32 +579,10 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
             auth: { apiKey: test_api_key },
         })
 
-        let pipelineStarted = false
-        try {
-            await endpoint.connect()
-            const session = await endpoint.session()
-            expect(session.pipelineId).toBeUndefined()
-            expect(endpoint.pop()).toEqual(test_transient_pop)
-            expect(pollSessionRoute).toHaveBeenCalledTimes(0)
-            expect(listPipelinesRoute).toHaveBeenCalledTimes(0)
-            expect(startPipelineRoute).toHaveBeenCalledTimes(0)
-
-            const stream = await endpoint.process({ source: { url: 'https://example.com/person.jpg' } })
-            const predictions = []
-            for await (const prediction of stream) {
-                predictions.push(prediction)
-            }
-
-            expect(predictions).toHaveLength(1)
-            expect(pollSessionRoute).toHaveBeenCalledTimes(0)
-            expect(startPipelineRoute).toHaveBeenCalledTimes(1)
-            expect(sourceRoute).toHaveBeenCalledTimes(1)
-            pipelineStarted = true
-        } finally {
-            await endpoint.disconnect()
-            if (pipelineStarted) {
-                expect(stopRoute).toHaveBeenCalledTimes(1)
-            }
-        }
+        await expect(endpoint.connect()).rejects.toThrow('Compute session did not provide a pipeline for the requested pop')
+        expect(endpoint.pop()).toEqual(test_transient_pop)
+        expect(pollSessionRoute).toHaveBeenCalledTimes(0)
+        expect(listPipelinesRoute).toHaveBeenCalledTimes(0)
+        expect(startPipelineRoute).toHaveBeenCalledTimes(0)
     })
 })


### PR DESCRIPTION
## Summary
- Creates Pop-backed transient sessions through `POST /v1/sessions?wait=true` without the deprecated `transient=true` query parameter.
- Relies on compute-api returning the owned runtime pipeline for inline Pop session creation.
- Routes `changePop` through compute and defers multi-scenario smoke cleanup until suite end.

## Dependency
- Requires compute-api PR https://github.com/eyepop-ai/eyepop-compute-api/pull/331 to land and deploy before releasing this SDK change.

## Changes
- Updated `WorkerEndpoint` transient compute session creation and `changePop` flow.
- Updated transient endpoint tests to assert compute-created pipeline ownership and no direct fallback when compute returns no pipeline.
- Updated `scripts/session-smoke.mjs` so `all-transient` does not delete a fresh transient session between scenarios.
- Updated docs to describe SDK-created sessions as `wait=true`; persistent deployments remain a separate `/v1/deployments` path.

## Test plan
- [x] `npm --workspace @eyepop.ai/eyepop run build`
- [x] `npm --workspace @eyepop.ai/react-native-eyepop run typecheck`
- [x] `npm --workspace @eyepop.ai/eyepop-render-2d run build`
- [x] `npx jest tests/eyepop/compute/compute_session.test.ts --runInBand`
- [x] `npx jest --runInBand --testPathIgnorePatterns="<rootDir>/.worktrees"`
- [x] Normal staging integration wrapper: `/Users/ryan/Code/eyepop/eyepop-integration-tests/scripts/run-sdk-smokes.sh` passed with Python + Node all-transient artifacts under `/Users/ryan/Code/eyepop/eyepop-integration-tests/artifacts/full-pr188-20260708170846`.