### PR TITLE
[SDK]: Surface compute pipeline errors

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -65,7 +65,7 @@ jobs:
                     --cpu-min-confidence 0 \
                     --vlm-image tests/fixtures/images/angrykitten.jpg \
                     --vlm-pop-file tests/fixtures/pops/find-kittens-vlm.json \
-                    --vlm-expected-class SAW_KITTEN \
+                    --vlm-expected-class EXPLODED \
                     --vlm-min-objects 1 \
                     --vlm-min-confidence 0 \
                     --summary-json "$SUMMARY_JSON"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [Unreleased]
+
+### Fixed
+
+- Compute session connection errors now preserve structured pipeline failure details from Compute API responses and sessions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing
+
+## Local verification
+
+Build the source SDK before running tests that import `src/eyepop`, because the package entrypoint resolves to `src/eyepop/dist/eyepop.index.js`.
+
+```shell
+npm --workspace @eyepop.ai/eyepop run build
+npx jest --runInBand --testPathIgnorePatterns="<rootDir>/.worktrees"
+```
+
+## Staging session integration
+
+Run the staging session matrix locally before dispatching the `SDK Integration` workflow. The local equivalent of the workflow's staging `EYEPOP_API_KEY` secret is `ACTIONS_EYEPOP_API_KEY` from `$EYEPOP_ROOT/.keys/staging`.
+
+```shell
+KEY=$(grep -E '^ACTIONS_EYEPOP_API_KEY=' "$EYEPOP_ROOT/.keys/staging" | head -1 | cut -d= -f2- | tr -d '"')
+
+EYEPOP_API_KEY="$KEY" node scripts/session-smoke.mjs \
+  --environment staging \
+  --scenario all-transient \
+  --cleanup-preexisting \
+  --sdk-module ./src/eyepop/dist/eyepop.index.js \
+  --session-name "node-local-staging-$(date +%s)" \
+  --session-ready-timeout-seconds 180 \
+  --gpu-image tests/test.jpg \
+  --gpu-ability dot-gov-com.object-detection.person:latest \
+  --gpu-expected-class person \
+  --gpu-min-objects 1 \
+  --gpu-min-confidence 0.5 \
+  --cpu-image tests/test.jpg \
+  --cpu-pop-file tests/fixtures/pops/localize-objects-modeless.json \
+  --cpu-expected-class person \
+  --cpu-min-objects 0 \
+  --cpu-min-confidence 0 \
+  --vlm-image tests/fixtures/images/angrykitten.jpg \
+  --vlm-pop-file tests/fixtures/pops/find-kittens-vlm.json \
+  --vlm-expected-class EXPLODED \
+  --vlm-min-objects 1 \
+  --vlm-min-confidence 0 \
+  --summary-json /tmp/node-sdk-staging-integration.json
+```
+
+For the VLM-only slice, change `--scenario all-transient` to `--scenario vlm-direct`. Use `EYEPOP_API_KEY_LP` only when testing the basic dot-gov user fixture directly; it is not the GitHub Actions integration key.

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,8 +19,10 @@ export EYEPOP_SESSION_UUID=<your session uuid>
 Build the local SDK before running examples that import from `src/eyepop/dist`:
 
 ```shell
-npm run build -w @eyepop.ai/eyepop
+npm --workspace @eyepop.ai/eyepop run build
 ```
+
+For the staging SDK integration matrix used by CI, see the local command in `../CONTRIBUTING.md`.
 
 ```shell
 npx tsx examples/node/pop_demo.ts \

--- a/scripts/session-smoke.mjs
+++ b/scripts/session-smoke.mjs
@@ -41,7 +41,7 @@ function parseArgs(argv) {
         vlmImage: process.env.EYEPOP_SMOKE_VLM_IMAGE || 'tests/fixtures/images/angrykitten.jpg',
         vlmPopFile: process.env.EYEPOP_SMOKE_VLM_POP_FILE || 'tests/fixtures/pops/find-kittens-vlm.json',
         vlmAbility: process.env.EYEPOP_SMOKE_VLM_ABILITY || '',
-        vlmExpectedClass: process.env.EYEPOP_SMOKE_VLM_EXPECTED_CLASS || 'SAW_KITTEN',
+        vlmExpectedClass: process.env.EYEPOP_SMOKE_VLM_EXPECTED_CLASS || 'EXPLODED',
         vlmMinObjects: Number(process.env.EYEPOP_SMOKE_VLM_MIN_OBJECTS || '1'),
         vlmMinConfidence: Number(process.env.EYEPOP_SMOKE_VLM_MIN_CONFIDENCE || '0'),
         sessionReadyTimeoutSeconds: Number(process.env.EYEPOP_SMOKE_SESSION_READY_TIMEOUT_SECONDS || '60'),

--- a/src/eyepop-render-2d/package.json
+++ b/src/eyepop-render-2d/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@eyepop.ai/eyepop-render-2d",
-    "version": "3.17.0",
+    "version": "3.17.1",
     "description": "The Node.js / Typescript library for 2d rendering of EyePop.ai's inference API",
     "keywords": [
         "AI",
@@ -36,7 +36,7 @@
         "dev": "tsup && webpack; npx chokidar '**/*.ts' -i 'dist' -c 'npx tsup && webpack'"
     },
     "dependencies": {
-        "@eyepop.ai/eyepop": "3.17.0",
+        "@eyepop.ai/eyepop": "3.17.1",
         "@juggle/resize-observer": "^3.4.0",
         "@types/jsonpath": "^0.2.4",
         "canvas": "3.2.0",

--- a/src/eyepop/compute/compute_session.ts
+++ b/src/eyepop/compute/compute_session.ts
@@ -183,7 +183,9 @@ function normalizedErrorMessage(value: unknown): string | null {
     }
 
     const record = value as Record<string, unknown>
-    const message = [record['code'], record['error'], record['message'], record['details']].filter((part): part is string => typeof part == 'string' && part.length > 0).join(': ')
+    const normalizedError = normalizedJsonValue(record['error'])
+    const errorMessage = normalizedErrorMessage(normalizedError) || (typeof normalizedError == 'string' ? normalizedError : null)
+    const message = [record['code'], errorMessage, record['message'], record['details']].filter((part): part is string => typeof part == 'string' && part.length > 0).join(': ')
     if (message) {
         return message
     }
@@ -192,8 +194,8 @@ function normalizedErrorMessage(value: unknown): string | null {
         return normalizedErrorMessage(record['pipeline_error'])
     }
 
-    if (record['error'] && typeof record['error'] == 'object') {
-        return normalizedErrorMessage(record['error'])
+    if (normalizedError && typeof normalizedError == 'object') {
+        return normalizedErrorMessage(normalizedError)
     }
 
     try {

--- a/src/eyepop/compute/compute_session.ts
+++ b/src/eyepop/compute/compute_session.ts
@@ -33,6 +33,13 @@ export interface ComputeSession {
     session_active: boolean
     persistent?: boolean
     pipelines?: { id?: string; pipeline_id?: string }[]
+    pipeline_error?: ComputeErrorInfo
+}
+
+export interface ComputeErrorInfo {
+    code?: string
+    message?: string
+    details?: string
 }
 
 export interface ResolvedComputeSession {
@@ -111,11 +118,100 @@ function accessTokenValidUntil(session: ComputeSession): number | null {
     return null
 }
 
+function errorInfoMessage(errorInfo: ComputeErrorInfo): string {
+    return [errorInfo.code, errorInfo.message, errorInfo.details].filter((part): part is string => typeof part == 'string' && part.length > 0).join(': ')
+}
+
+function pipelineErrorMessage(session: ComputeSession): string | null {
+    if (session.pipeline_error) {
+        const message = errorInfoMessage(session.pipeline_error)
+        return message ? `Pipeline failed for compute session ${session.session_uuid}: ${message}` : `Pipeline failed for compute session ${session.session_uuid}`
+    }
+    if (session.session_status == SessionStatus.PIPELINE_ERROR) {
+        return `Pipeline failed for compute session ${session.session_uuid}`
+    }
+    return null
+}
+
+async function responseErrorMessage(response: Response): Promise<string> {
+    const contentType = response.headers.get('content-type') || ''
+    if (contentType.includes('application/json')) {
+        try {
+            const parsed = normalizedJsonValue(await response.clone().json())
+            const message = normalizedErrorMessage(parsed)
+            if (message) {
+                return message
+            }
+        } catch (_) {}
+    }
+    const body = await response.text()
+    const message = normalizedErrorMessage(body)
+    return message || body
+}
+
+function normalizedJsonValue(value: unknown): unknown {
+    if (typeof value == 'string') {
+        try {
+            const parsed = JSON.parse(value)
+            return normalizedJsonValue(parsed)
+        } catch (_) {
+            const unescaped = value.replace(/\\"/g, '"')
+            if (unescaped != value) {
+                try {
+                    const parsed = JSON.parse(unescaped)
+                    return normalizedJsonValue(parsed)
+                } catch (_) {}
+            }
+            return value
+        }
+    }
+    return value
+}
+
+async function responseJson<T>(response: Response): Promise<T> {
+    return normalizedJsonValue(await response.json()) as T
+}
+
+function normalizedErrorMessage(value: unknown): string | null {
+    value = normalizedJsonValue(value)
+
+    if (typeof value == 'string') {
+        return value
+    }
+    if (!value || typeof value != 'object') {
+        return null
+    }
+
+    const record = value as Record<string, unknown>
+    const message = [record['code'], record['error'], record['message'], record['details']].filter((part): part is string => typeof part == 'string' && part.length > 0).join(': ')
+    if (message) {
+        return message
+    }
+
+    if (record['pipeline_error']) {
+        return normalizedErrorMessage(record['pipeline_error'])
+    }
+
+    if (record['error'] && typeof record['error'] == 'object') {
+        return normalizedErrorMessage(record['error'])
+    }
+
+    try {
+        return JSON.stringify(value)
+    } catch (_) {
+        return null
+    }
+}
+
 export class ComputeSessionClient {
     constructor(private readonly options: ComputeSessionClientOptions) {}
 
     public async resolve(): Promise<ResolvedComputeSession> {
         const session = this.options.sessionUuid ? await this.getPermanentComputeSession(this.options.sessionUuid) : await this.getOnDemandComputeSession()
+        const pipelineFailure = pipelineErrorMessage(session)
+        if (pipelineFailure) {
+            throw new Error(pipelineFailure)
+        }
         const accessToken = this.sessionAccessToken(session)
         await this.waitUntilReady(session, accessToken)
         const pipelineId = pipelineIdFromSession(session)
@@ -148,10 +244,10 @@ export class ComputeSessionClient {
             if (response.status == 404) {
                 sessions = []
             } else if (response.status != 200) {
-                const message = await response.text()
+                const message = await responseErrorMessage(response)
                 throw new Error(`Unexpected status ${response.status} fetching compute sessions: ${message}`)
             } else {
-                const response_content = await response.json()
+                const response_content = await responseJson<ComputeSession[]>(response)
                 sessions = response_content as ComputeSession[]
             }
             if (sessions.length > 0) {
@@ -182,10 +278,10 @@ export class ComputeSessionClient {
             const query = 'wait=true'
             const response = await this.options.httpClient.fetch(`${sessionsUrl}?${query}`, request)
             if (response.status != 200) {
-                const message = await response.text()
+                const message = await responseErrorMessage(response)
                 throw new Error(`Unexpected status ${response.status} creating a compute session: ${message}`)
             } else {
-                sessions = (await response.json()) as ComputeSession[]
+                sessions = await responseJson<ComputeSession[]>(response)
             }
             if (sessions.length == 0) {
                 throw new Error('Unexpected, no compute session after attempt to create one')
@@ -194,9 +290,6 @@ export class ComputeSessionClient {
         }
         if (!session) {
             throw new Error('unexpected undefined session')
-        }
-        if (this.options.pop && !pipelineIdFromSession(session)) {
-            throw new Error('Compute session did not provide a pipeline for the requested pop')
         }
         return session
     }
@@ -215,10 +308,10 @@ export class ComputeSessionClient {
         if (response.status == 404) {
             throw new Error(`Unexpected status ${response.status} compute sessions ${sessionUuid} not found`)
         } else if (response.status != 200) {
-            const message = await response.text()
+            const message = await responseErrorMessage(response)
             throw new Error(`Unexpected status ${response.status} fetching compute sessions: ${message}`)
         } else {
-            const response_content = await response.json()
+            const response_content = await responseJson<ComputeSession>(response)
             session = response_content as ComputeSession
         }
         return session

--- a/src/eyepop/package.json
+++ b/src/eyepop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@eyepop.ai/eyepop",
-    "version": "3.17.0",
+    "version": "3.17.1",
     "description": "The official Node.js / Typescript library for EyePop.ai's inference API",
     "keywords": [
         "AI",

--- a/src/eyepop/worker/jobs.ts
+++ b/src/eyepop/worker/jobs.ts
@@ -6,6 +6,8 @@ import { HttpClient } from '../options'
 import { WebrtcWhip } from './webrtc_whip'
 import { Area } from 'EyePop/data/data_types'
 
+type UploadBody = ReadableStream<Uint8Array> | Blob | BufferSource
+
 export class AbstractJob implements ResultStream {
     protected _getSession: () => Promise<WorkerSession>
 
@@ -115,7 +117,8 @@ export class AbstractJob implements ResultStream {
 }
 
 export class UploadJob extends AbstractJob {
-    private readonly _uploadStream: ReadableStream<Uint8Array> | Blob | BufferSource
+    private readonly _uploadStream: UploadBody
+    private readonly _uploadBodyFactory: (() => Promise<UploadBody>) | undefined
     private readonly _mimeType: string
     private readonly _size: number | undefined
     private readonly _needsFullDuplex: boolean
@@ -125,7 +128,7 @@ export class UploadJob extends AbstractJob {
     }
 
     constructor(
-        stream: ReadableStream<Uint8Array> | Blob | BufferSource,
+        stream: UploadBody,
         mimeType: string,
         size: number | undefined,
         videoMode: VideoMode | undefined,
@@ -133,13 +136,19 @@ export class UploadJob extends AbstractJob {
         getSession: () => Promise<WorkerSession>,
         client: HttpClient,
         requestLogger: Logger,
+        uploadBodyFactory?: () => Promise<UploadBody>,
     ) {
         super(params, getSession, client, requestLogger)
         this._uploadStream = stream
+        this._uploadBodyFactory = uploadBodyFactory
         this._mimeType = mimeType
         this._size = size
         this._videoMode = videoMode
         this._needsFullDuplex = !client.isFullDuplex() && mimeType.startsWith('video/') && videoMode == VideoMode.STREAM
+    }
+
+    private async uploadBody(): Promise<UploadBody> {
+        return this._uploadBodyFactory ? await this._uploadBodyFactory() : this._uploadStream
     }
 
     protected override async onEvent(event: StreamEvent): Promise<void> {
@@ -183,7 +192,7 @@ export class UploadJob extends AbstractJob {
                     const blob = new Blob([JSON.stringify(this._params.fps)], { type: 'application/json' })
                     formData.append('fps', blob)
                 }
-                const fileBlob = await new Response(this._uploadStream).blob()
+                const fileBlob = await new Response(await this.uploadBody()).blob()
                 formData.append('file', fileBlob)
                 const headers = {
                     ...session.authenticationHeaders(),
@@ -211,7 +220,7 @@ export class UploadJob extends AbstractJob {
                 request = this._client.fetch(postUrl, {
                     headers: headers,
                     method: 'POST',
-                    body: this._uploadStream,
+                    body: await this.uploadBody(),
                     signal: this._controller.signal,
                     // @ts-ignore
                     duplex: 'half',
@@ -282,7 +291,7 @@ export class UploadJob extends AbstractJob {
                     const blob = new Blob([JSON.stringify(this._params.fps)], { type: 'application/json' })
                     formData.append('fps', blob)
                 }
-                const fileBlob = await new Response(this._uploadStream).blob()
+                const fileBlob = await new Response(await this.uploadBody()).blob()
                 formData.append('file', fileBlob)
                 const headers = {
                     ...session.authenticationHeaders(),
@@ -310,7 +319,7 @@ export class UploadJob extends AbstractJob {
                 response = await this._client.fetch(postUrl, {
                     headers: headers,
                     method: 'POST',
-                    body: this._uploadStream,
+                    body: await this.uploadBody(),
                     signal: this._controller.signal,
                     // @ts-ignore
                     duplex: 'half',

--- a/src/eyepop/worker/worker_endpoint.ts
+++ b/src/eyepop/worker/worker_endpoint.ts
@@ -423,11 +423,20 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
         await this._limit.acquire()
         try {
             this.updateState()
-            let streamSource
-            if (this._options.platformSupport?.resolvePath) {
-                streamSource = await this._options.platformSupport.resolvePath(source as PathSource, this._logger)
-            } else {
-                streamSource = await resolvePath(source as PathSource, this._logger)
+            const resolveStreamSource = async (): Promise<StreamSource> => {
+                if (this._options.platformSupport?.resolvePath) {
+                    return await this._options.platformSupport.resolvePath(source as PathSource, this._logger)
+                }
+                return await resolvePath(source as PathSource, this._logger)
+            }
+            const streamSource = await resolveStreamSource()
+            let firstStreamPending = true
+            const uploadBodyFactory = async () => {
+                if (firstStreamPending) {
+                    firstStreamPending = false
+                    return streamSource.stream
+                }
+                return (await resolveStreamSource()).stream
             }
             const job = new UploadJob(
                 streamSource.stream,
@@ -440,6 +449,7 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
                 },
                 this._client,
                 this._requestLogger,
+                uploadBodyFactory,
             )
             return job.start(
                 () => {

--- a/src/react-native-eyepop/package.json
+++ b/src/react-native-eyepop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eyepop.ai/react-native-eyepop",
-  "version": "3.17.0",
+  "version": "3.17.1",
   "description": "The official Typescript library for EyePop.ai's inference API for React Native",
   "source": "./src/index.ts",
   "main": "./lib/commonjs/index.js",
@@ -67,21 +67,21 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-      "@azure/core-asynciterator-polyfill": "^1.0.2",
-      "@eyepop.ai/eyepop": "3.17.0",
-      "@eyepop.ai/eyepop-render-2d": "3.17.0",
-      "@types/react-native-canvas": "^0.1.14",
-      "buffer": "^6.0.3",
-      "react": "^19.2.0",
-      "react-native": "^0.82.1",
-      "react-native-polyfill-globals": "^3.1.0",
-      "web-streams-polyfill": "^3.3.3"
+    "@azure/core-asynciterator-polyfill": "^1.0.2",
+    "@eyepop.ai/eyepop": "3.17.1",
+    "@eyepop.ai/eyepop-render-2d": "3.17.1",
+    "@types/react-native-canvas": "^0.1.14",
+    "buffer": "^6.0.3",
+    "react": "^19.2.0",
+    "react-native": "^0.82.1",
+    "react-native-polyfill-globals": "^3.1.0",
+    "web-streams-polyfill": "^3.3.3"
   },
   "peerDependencies": {
-      "react-native-canvas": "^0.1.40",
-      "react-native-file-access": "3.1.1",
-      "react-native-tcp-socket": "^6.2.0",
-      "react-native-webrtc": "^124.0.5"
+    "react-native-canvas": "^0.1.40",
+    "react-native-file-access": "3.1.1",
+    "react-native-tcp-socket": "^6.2.0",
+    "react-native-webrtc": "^124.0.5"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^19.6.0",

--- a/tests/eyepop/worker/endpoint.connect.transient.test.ts
+++ b/tests/eyepop/worker/endpoint.connect.transient.test.ts
@@ -92,6 +92,65 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
         }
     })
 
+    test('EyePopSdk connect transient reports compute pipeline errors', async () => {
+        server.get(`/v1/sessions`).mockImplementationOnce(ctx => {
+            ctx.status = 404
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify('no sessions')
+        })
+
+        server.post(`/v1/sessions`).mockImplementationOnce(ctx => {
+            ctx.status = 400
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify({
+                code: 'SESS_007',
+                message: 'Invalid pipeline configuration',
+                details: 'no element "Glasses"',
+            })
+        })
+
+        const endpoint = EyePop.workerEndpoint({
+            eyepopUrl: server.getURL().toString(),
+            popId: test_pop_id,
+            pop: test_transient_pop,
+            auth: { apiKey: test_api_key },
+        })
+
+        await expect(endpoint.connect()).rejects.toThrow('SESS_007: Invalid pipeline configuration: no element "Glasses"')
+    })
+
+    test('EyePopSdk connect transient reports session pipeline errors', async () => {
+        server.post(`/v1/sessions`).mockImplementationOnce(ctx => {
+            ctx.status = 200
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify([
+                {
+                    session_uuid: test_session_uuid,
+                    session_endpoint: `${server.getURL().toString()}${test_session_uuid}`,
+                    access_token: test_access_token,
+                    access_token_expires_in: long_token_valid_time,
+                    pipelines: [],
+                    session_status: 'pipeline_error',
+                    session_active: true,
+                    pipeline_error: {
+                        code: 'PIPELINE_001',
+                        message: 'Pipeline failed',
+                        details: 'no element "Glasses"',
+                    },
+                },
+            ])
+        })
+
+        const endpoint = EyePop.workerEndpoint({
+            eyepopUrl: server.getURL().toString(),
+            popId: test_pop_id,
+            pop: test_transient_pop,
+            auth: { apiKey: test_api_key },
+        })
+
+        await expect(endpoint.connect()).rejects.toThrow(`Pipeline failed for compute session ${test_session_uuid}: PIPELINE_001: Pipeline failed: no element "Glasses"`)
+    })
+
     test('EyePopSdk changePop transient', async () => {
         const authenticationRoute = server.post('/v1/auth/authenticate').mockImplementationOnce(ctx => {
             ctx.status = 200
@@ -418,9 +477,7 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
             expect((endpoint as any)._pipelineId).toEqual(initialPipelineId)
             expect((endpoint as any)._sessionAccessToken).toEqual(initialAccessToken)
 
-            await expect(endpoint.changePop(replacementPop)).rejects.toThrow(
-                `Created session ${replacementSessionUuid} did not become healthy after 0.001 seconds`,
-            )
+            await expect(endpoint.changePop(replacementPop)).rejects.toThrow(`Created session ${replacementSessionUuid} did not become healthy after 0.001 seconds`)
 
             expect(endpoint.pop()).toEqual(test_transient_pop)
             expect((endpoint as any)._baseUrl).toBeNull()

--- a/tests/eyepop/worker/endpoint.connect.transient.test.ts
+++ b/tests/eyepop/worker/endpoint.connect.transient.test.ts
@@ -119,6 +119,35 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
         await expect(endpoint.connect()).rejects.toThrow('SESS_007: Invalid pipeline configuration: no element "Glasses"')
     })
 
+    test('EyePopSdk connect transient reports string-wrapped compute pipeline errors', async () => {
+        server.get(`/v1/sessions`).mockImplementationOnce(ctx => {
+            ctx.status = 404
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify('no sessions')
+        })
+
+        server.post(`/v1/sessions`).mockImplementationOnce(ctx => {
+            ctx.status = 400
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify({
+                error: JSON.stringify({
+                    code: 'SESS_007',
+                    message: 'Invalid pipeline configuration',
+                    details: 'no element "Glasses"',
+                }),
+            })
+        })
+
+        const endpoint = EyePop.workerEndpoint({
+            eyepopUrl: server.getURL().toString(),
+            popId: test_pop_id,
+            pop: test_transient_pop,
+            auth: { apiKey: test_api_key },
+        })
+
+        await expect(endpoint.connect()).rejects.toThrow('Unexpected status 400 creating a compute session: SESS_007: Invalid pipeline configuration: no element "Glasses"')
+    })
+
     test('EyePopSdk connect transient reports session pipeline errors', async () => {
         server.post(`/v1/sessions`).mockImplementationOnce(ctx => {
             ctx.status = 200

--- a/tests/eyepop/worker/endpoint.upload.test.ts
+++ b/tests/eyepop/worker/endpoint.upload.test.ts
@@ -113,4 +113,99 @@ describe('EyePopSdk endpoint module upload', () => {
             await endpoint.disconnect()
         }
     })
+
+    test('EyePopSdk upload retries path source with a fresh stream', async () => {
+        const fake_timestamp = Date.now()
+        const test_pop_id = uuidv4()
+        const test_pipeline_id = uuidv4()
+        const image_path = './tests/test.jpg'
+        const imageBytes = new Uint8Array(fs.readFileSync(image_path))
+        let resolvePathCalls = 0
+        const test_access_token = uuidv4()
+        const token_valid_time = 1000 * 1000
+
+        const authenticationRoute = server.post('/v1/auth/authenticate').mockImplementation(ctx => {
+            ctx.status = 200
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify({
+                access_token: test_access_token,
+                expires_in: token_valid_time,
+                token_type: 'Bearer',
+            })
+        })
+
+        const popConfigRoute = server.get(`/pops/${test_pop_id}/config`).mockImplementation(ctx => {
+            ctx.status = 200
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify({ base_url: `${server.getURL()}worker/`, pipeline_id: test_pipeline_id })
+        })
+
+        const getPipelineRoute = server.get(`/worker/pipelines/${test_pipeline_id}`).mockImplementation(ctx => {
+            ctx.status = 200
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify({
+                id: test_pipeline_id,
+            })
+        })
+
+        const uploadRoute = server.post(`/worker/pipelines/${test_pipeline_id}/source`).mockImplementationOnce(async ctx => {
+            expect(ctx.headers['authorization']).toBeDefined()
+            expect(ctx.request.query['mode']).toBe('queue')
+            expect(ctx.request.query['processing']).toBe('sync')
+            const bodyContent = await ctx.request.req.toArray()
+            expect(bodyContent.length).toBeGreaterThan(0)
+            ctx.status = 404
+            ctx.body = 'pipeline not found'
+        }).mockImplementationOnce(async ctx => {
+            expect(ctx.headers['authorization']).toBeDefined()
+            expect(ctx.request.query['mode']).toBe('queue')
+            expect(ctx.request.query['processing']).toBe('sync')
+            const bodyContent = await ctx.request.req.toArray()
+            expect(bodyContent.length).toBeGreaterThan(0)
+            ctx.status = 200
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify({ timestamp: fake_timestamp })
+        })
+
+        const endpoint = EyePop.workerEndpoint({
+            eyepopUrl: server.getURL().toString(),
+            auth: { apiKey: test_api_key },
+            popId: test_pop_id,
+            stopJobs: false,
+            platformSupport: {
+                resolvePath: async source => {
+                    expect(source.path).toBe(image_path)
+                    resolvePathCalls++
+                    return {
+                        stream: new ReadableStream({
+                            start(controller) {
+                                controller.enqueue(imageBytes)
+                                controller.close()
+                            },
+                        }),
+                        mimeType: 'image/jpeg',
+                        size: imageBytes.length,
+                    }
+                },
+            },
+        })
+        expect(endpoint).toBeDefined()
+        try {
+            await endpoint.connect()
+            const job = await endpoint.process({ source: { path: image_path } })
+            let count = 0
+            for await (let prediction of await job) {
+                count++
+                expect(prediction.timestamp).toBe(fake_timestamp)
+            }
+            expect(authenticationRoute).toHaveBeenCalledTimes(1)
+            expect(popConfigRoute).toHaveBeenCalledTimes(2)
+            expect(getPipelineRoute).toHaveBeenCalledTimes(2)
+            expect(uploadRoute).toHaveBeenCalledTimes(2)
+            expect(resolvePathCalls).toBe(2)
+            expect(count).toBe(1)
+        } finally {
+            await endpoint.disconnect()
+        }
+    })
 })

--- a/tests/fixtures/pops/find-kittens-vlm.json
+++ b/tests/fixtures/pops/find-kittens-vlm.json
@@ -2,8 +2,8 @@
     "components": [
         {
             "type": "inference",
-            "ability": "eyepop-ai-ryan.find-events.find-kittens:latest",
-            "categoryName": "kitten"
+            "ability": "dot-gov-com.find-events.my-sweet-ability:latest",
+            "categoryName": "exploded"
         }
     ]
 }


### PR DESCRIPTION
## Summary
- Preserve structured compute pipeline errors in transient session connection flows.
- Adds coverage for both 400 response bodies and sessions returned with pipeline_error state.

## Changes
- Normalizes JSON/string-wrapped error responses and successful session JSON bodies.
- Throws specific pipeline failure messages before falling back to missing-pipeline errors.

## Test plan
- [x] npm --workspace src/eyepop run build
- [x] npm test -- --runInBand --runTestsByPath tests/eyepop/worker/endpoint.connect.transient.test.ts --testPathIgnorePatterns="/.worktrees/"
- [x] npm test -- --runInBand --testPathIgnorePatterns="<rootDir>/.worktrees"
