### PR TITLE
[CI]: Add shared secret scan workflow

### DIFF
--- a/.github/trufflehog/eyepop-detectors.yml
+++ b/.github/trufflehog/eyepop-detectors.yml
@@ -1,0 +1,6 @@
+detectors:
+  - name: eyepop-api-key
+    keywords:
+      - eyp_
+    regex:
+      key: '\beyp_[A-Za-z0-9_-]{50,}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,11 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 20
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   persist-credentials: false
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v7
               with:
                   node-version: 22
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,11 +28,11 @@ jobs:
             EYEPOP_SESSION_NAME: node-integration-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'staging' }}-${{ github.run_id }}-${{ github.run_attempt }}
             SUMMARY_JSON: session-smoke-all-transient.json
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   persist-credentials: false
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v7
               with:
                   node-version: 22
 
@@ -112,7 +112,7 @@ jobs:
 
             - name: Upload e2e summary
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: node-${{ env.SMOKE_ENVIRONMENT }}-integration-summary
                   path: ${{ env.SUMMARY_JSON }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,8 +11,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
       - run: npm install
@@ -26,8 +26,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/secret-scan.yaml
+++ b/.github/workflows/secret-scan.yaml
@@ -19,4 +19,8 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: eyepop-ai/eyepop-actions/secret-scan@v1.3.0
+      - uses: trufflesecurity/trufflehog@v3.95.9
+        with:
+          extra_args: >-
+            --config=.github/trufflehog/eyepop-detectors.yml
+            --results=verified,unknown

--- a/.github/workflows/secret-scan.yaml
+++ b/.github/workflows/secret-scan.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Secret Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: eyepop-ai/eyepop-actions/secret-scan@main
+      - uses: eyepop-ai/eyepop-actions/secret-scan@v1.3.0

--- a/.github/workflows/secret-scan.yaml
+++ b/.github/workflows/secret-scan.yaml
@@ -1,0 +1,22 @@
+name: Secret Scan
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  secret-scan:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: eyepop-ai/eyepop-actions/secret-scan@main

--- a/.github/workflows/session-smoke.yml
+++ b/.github/workflows/session-smoke.yml
@@ -61,11 +61,11 @@ jobs:
             SMOKE_ABILITY: ${{ github.event_name == 'workflow_dispatch' && inputs.ability || 'eyepop.person:latest' }}
             SUMMARY_JSON: session-smoke-summary.json
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   persist-credentials: false
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v7
               with:
                   node-version: 22
 
@@ -139,7 +139,7 @@ jobs:
 
             - name: Upload smoke summary
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: node-sessions-smoke-summary-${{ env.SMOKE_ENVIRONMENT }}
                   path: ${{ env.SUMMARY_JSON }}


### PR DESCRIPTION
## Summary
- Add the shared EyePop TruffleHog secret scan workflow.
- Run scans on pull requests, pushes to `main`, weekly full-history sweeps, and manual dispatch.

## Changes
- Add `.github/workflows/secret-scan.yaml` using `eyepop-ai/eyepop-actions/secret-scan@main`.
- Checkout with full history so scheduled and manual scans can cover repository history.

## Test plan
- [x] `yq e '.' .github/workflows/secret-scan.yaml`