### PR TITLE
docs: concise CLAUDE.md agent guide + gitignore agent artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,19 @@ examples/web/static/env.js
 
 examples/react_native/*/android
 examples/react_native/*/ios
+
+# Agent / planning artifacts — never committed (untracked, kept local)
+HANDOFF.md
+CONTEXT.md
+docs/CONTEXT.md
+docs/CONTEXT-MAP.md
+docs/adr/
+docs/adrs/
+docs/prd/
+docs/prds/
+docs/pdr/
+docs/issues/
+docs/agents/
+docs/superpowers/
+superpowers/
+docs/postmortems/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,21 @@
+# eyepop-sdk-node
+
+Official Node.js / TypeScript SDK for EyePop.ai's inference API — connect to worker sessions and process
+images/videos through vision pipelines ("Pops"). npm-workspaces monorepo (`src/eyepop`, `eyepop-render-2d`, `react-native-eyepop`).
+
+## Commands
+npm workspaces (not pnpm/yarn/go-task). No single check task. Unit tests: `npm test` (jest, fully mocked).
+Before done, mirror CI (`.github/workflows/ci.yml`, Node 22): build `@eyepop.ai/eyepop` + `eyepop-render-2d`,
+`typecheck` `react-native-eyepop`, then `npx jest --runInBand`.
+
+## Gotchas
+- Dual node+browser codebase: `build` = `tsup` (CJS+ESM+dts) then `webpack` browser bundle; the `browser` field
+  stubs Node built-ins (`fs`, `undici`, `ws` → false). Those overrides are load-bearing — don't assume Node APIs are safe.
+- Jest runs ESM against raw TS `src/` (no build needed), but relative imports must carry a `.js` extension
+  (ESM convention) even though the files are `.ts` — omitting it breaks resolution.
+- Unit tests are hermetic (mock server / fake HttpClient); the smoke/live tests (`npm run smoke:session`,
+  `scripts/session-smoke.mjs`) hit real hosts and need `EYEPOP_API_KEY`.
+- Publish is GitHub-Release-triggered and idempotent (skips any `name@version` already on npm). All three
+  workspaces share one version with exact inter-pins — bump them in lockstep; `react-native-eyepop` has its own `release-it` path.
+- Version pins disagree (`engines` ≥18, README says 20, CI uses 22/24) and `lefthook.yml` is commented-out —
+  there are **no active git hooks**, so nothing auto-runs lint/tests locally.


### PR DESCRIPTION
Adds a concise, standardized `CLAUDE.md` (agent onboarding) to this repo.

**CLAUDE.md** — one-line purpose, `task --list-all` check-gate pointer, and non-obvious gotchas only. No directory maps, command dumps, or speculative filler (discoverable info deliberately excluded).

**Hygiene**
- `.gitignore`: ignore agent/planning artifacts (adr/prd/context/handoff/superpowers/postmortems)

Part of a fleet-wide agent-config standardization across EyePop repos.