### PR TITLE
[SDK]: Allow JWT auth for compute sessions without scoped token

### DIFF
--- a/src/eyepop-render-2d/package.json
+++ b/src/eyepop-render-2d/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@eyepop.ai/eyepop-render-2d",
-    "version": "3.17.1",
+    "version": "3.17.2",
     "description": "The Node.js / Typescript library for 2d rendering of EyePop.ai's inference API",
     "keywords": [
         "AI",
@@ -36,7 +36,7 @@
         "dev": "tsup && webpack; npx chokidar '**/*.ts' -i 'dist' -c 'npx tsup && webpack'"
     },
     "dependencies": {
-        "@eyepop.ai/eyepop": "3.17.1",
+        "@eyepop.ai/eyepop": "3.17.2",
         "@juggle/resize-observer": "^3.4.0",
         "@types/jsonpath": "^0.2.4",
         "canvas": "3.2.0",

--- a/src/eyepop/compute/compute_session.ts
+++ b/src/eyepop/compute/compute_session.ts
@@ -45,7 +45,7 @@ export interface ComputeErrorInfo {
 export interface ResolvedComputeSession {
     session: ComputeSession
     pipelineId: string | null
-    accessToken: string
+    accessToken: string | null
     accessTokenValidUntil: number | null
 }
 
@@ -214,8 +214,8 @@ export class ComputeSessionClient {
         if (pipelineFailure) {
             throw new Error(pipelineFailure)
         }
-        const accessToken = this.sessionAccessToken(session)
-        await this.waitUntilReady(session, accessToken)
+        const authorizationHeader = await this.sessionAuthorizationHeader(session)
+        await this.waitUntilReady(session, authorizationHeader)
         const pipelineId = pipelineIdFromSession(session)
         if (this.options.pop && !pipelineId) {
             throw new Error('Compute session did not provide a pipeline for the requested pop')
@@ -223,7 +223,7 @@ export class ComputeSessionClient {
         return {
             session,
             pipelineId,
-            accessToken,
+            accessToken: session.access_token || null,
             accessTokenValidUntil: accessTokenValidUntil(session),
         }
     }
@@ -319,21 +319,21 @@ export class ComputeSessionClient {
         return session
     }
 
-    private sessionAccessToken(session: ComputeSession): string {
-        if (!session.access_token) {
-            throw new Error(`Compute session ${session.session_uuid} did not provide an access token`)
+    private async sessionAuthorizationHeader(session: ComputeSession): Promise<string> {
+        if (session.access_token) {
+            return `Bearer ${session.access_token}`
         }
-        return session.access_token
+        return this.options.authorizationHeader()
     }
 
-    private async waitUntilReady(session: ComputeSession, accessToken: string): Promise<void> {
+    private async waitUntilReady(session: ComputeSession, authorizationHeader: string): Promise<void> {
         let isReady: boolean = false
         const deadline: number = Date.now() + this.options.readyTimeoutMs
         while (!isReady) {
             const health_url = `${session.session_endpoint}/health`
             const response = await this.options.httpClient.fetch(health_url, {
                 headers: {
-                    Authorization: `Bearer ${accessToken}`,
+                    Authorization: authorizationHeader,
                     Accept: 'application/json',
                 },
             })

--- a/src/eyepop/package.json
+++ b/src/eyepop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@eyepop.ai/eyepop",
-    "version": "3.17.1",
+    "version": "3.17.2",
     "description": "The official Node.js / Typescript library for EyePop.ai's inference API",
     "keywords": [
         "AI",

--- a/src/eyepop/shims/browser_session.ts
+++ b/src/eyepop/shims/browser_session.ts
@@ -1,7 +1,6 @@
 import { Session } from '../types'
 import { Auth0Options, Options } from '../options'
 import { createAuth0Client } from '@auth0/auth0-spa-js'
-import { Auth0ClientOptions } from '@auth0/auth0-spa-js/src/global'
 import { WorkerOptions, WorkerSession } from '../index'
 
 export let authenticateBrowserSession: (auth0: Auth0Options, options: Options) => Promise<Session>
@@ -11,7 +10,7 @@ if ('document' in globalThis && 'implementation' in globalThis.document) {
         if (options.eyepopUrl == null) {
             return Promise.reject('options.eyepopUrl cannot be null')
         }
-        const auth0ClientOptions: Auth0ClientOptions = {
+        const auth0ClientOptions = {
             clientId: auth0.clientId,
             domain: auth0.domain,
             authorizationParams: {

--- a/src/eyepop/shims/local_file.ts
+++ b/src/eyepop/shims/local_file.ts
@@ -13,7 +13,7 @@ if ('document' in globalThis && 'implementation' in globalThis.document) {
     /**
      * From https://github.com/MattMorgis/async-stream-generator
      */
-    async function* nodeStreamToIterator(stream: fs.ReadStream) {
+    async function* nodeStreamToIterator(stream: AsyncIterable<Uint8Array>) {
         for await (const chunk of stream) {
             yield chunk
         }
@@ -44,7 +44,7 @@ if ('document' in globalThis && 'implementation' in globalThis.document) {
         const filehandle = require('node:fs/promises')
         const fd = await filehandle.open(source.path, 'r')
         const stream = fd.createReadStream()
-        const iterator = nodeStreamToIterator(stream)
+        const iterator = nodeStreamToIterator(stream as AsyncIterable<Uint8Array>)
         const webStream = iteratorToStream(iterator)
 
         const mimeType = source.mimeType? source.mimeType : (mime.lookup(source.path) || 'image/*')

--- a/src/react-native-eyepop/package.json
+++ b/src/react-native-eyepop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eyepop.ai/react-native-eyepop",
-  "version": "3.17.1",
+  "version": "3.17.2",
   "description": "The official Typescript library for EyePop.ai's inference API for React Native",
   "source": "./src/index.ts",
   "main": "./lib/commonjs/index.js",
@@ -68,8 +68,8 @@
   },
   "dependencies": {
     "@azure/core-asynciterator-polyfill": "^1.0.2",
-    "@eyepop.ai/eyepop": "3.17.1",
-    "@eyepop.ai/eyepop-render-2d": "3.17.1",
+    "@eyepop.ai/eyepop": "3.17.2",
+    "@eyepop.ai/eyepop-render-2d": "3.17.2",
     "@types/react-native-canvas": "^0.1.14",
     "buffer": "^6.0.3",
     "react": "^19.2.0",

--- a/tests/eyepop/compute/compute_session.test.ts
+++ b/tests/eyepop/compute/compute_session.test.ts
@@ -2,20 +2,19 @@ import { describe, expect, test } from '@jest/globals'
 
 import { ComputeSessionClient, SessionStatus } from '../../../src/eyepop/compute/compute_session'
 import type { HttpClient } from '../../../src/eyepop/options'
-import { PopComponentType, type Pop } from '../../../src/eyepop'
+import { PopComponentType, type Pop } from '../../../src/eyepop/worker/worker_types'
 
 const computeUrl = 'https://compute.example.test'
 const sessionEndpoint = 'https://worker.example.test/session'
 const accessToken = 'session-token'
 
-function sessionResponse(pipelineId?: string) {
+function sessionResponse(pipelineId?: string, includeAccessToken = true) {
     return [
         {
             session_uuid: 'session-uuid',
             session_endpoint: sessionEndpoint,
             pipeline_uuid: pipelineId || '',
-            access_token: accessToken,
-            access_token_expires_in: 60,
+            ...(includeAccessToken ? { access_token: accessToken, access_token_expires_in: 60 } : {}),
             session_status: SessionStatus.RUNNING,
             session_message: '',
             session_name: 'node-sdk-test',
@@ -31,7 +30,7 @@ function sessionResponse(pipelineId?: string) {
 
 type FetchCall = { url: string; init: RequestInit | undefined }
 
-function createHttpClient(calls: FetchCall[], pipelineId?: string): HttpClient {
+function createHttpClient(calls: FetchCall[], pipelineId?: string, includeAccessToken = true): HttpClient {
     return {
         async fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
             const url = input.toString()
@@ -40,7 +39,7 @@ function createHttpClient(calls: FetchCall[], pipelineId?: string): HttpClient {
                 return new Response('not found', { status: 404 })
             }
             if (url.startsWith(`${computeUrl}/v1/sessions?`)) {
-                return new Response(JSON.stringify(sessionResponse(pipelineId)), {
+                return new Response(JSON.stringify(sessionResponse(pipelineId, includeAccessToken)), {
                     status: 200,
                     headers: { 'content-type': 'application/json' },
                 })
@@ -102,5 +101,25 @@ describe('ComputeSessionClient', () => {
         const createCall = calls.find(call => call.init?.method === 'POST')
         expect(createCall?.url).toBe(`${computeUrl}/v1/sessions?wait=true`)
         expect(JSON.parse(String(createCall?.init?.body))).toEqual({ pop })
+    })
+
+    test('uses caller authorization when compute session has no access token', async () => {
+        const calls: FetchCall[] = []
+        const callerAuthorizationHeader = 'Bearer user-jwt'
+
+        const resolved = await new ComputeSessionClient({
+            computeUrl,
+            httpClient: createHttpClient(calls, undefined, false),
+            authorizationHeader: async () => callerAuthorizationHeader,
+            readyTimeoutMs,
+        }).resolve()
+
+        const healthCall = calls.find(call => call.url === `${sessionEndpoint}/health`)
+        expect(healthCall?.init?.headers).toMatchObject({
+            Authorization: callerAuthorizationHeader,
+            Accept: 'application/json',
+        })
+        expect(resolved.accessToken).toBeNull()
+        expect(resolved.accessTokenValidUntil).toBeNull()
     })
 })

--- a/tests/eyepop/worker/endpoint.connect.transient.test.ts
+++ b/tests/eyepop/worker/endpoint.connect.transient.test.ts
@@ -1,4 +1,6 @@
-import { EyePop, PopComponentType, TransientPopId, Pop } from '../../../src/eyepop'
+import { WorkerEndpoint } from '../../../src/eyepop/worker/worker_endpoint'
+import { TransientPopId, type WorkerOptions } from '../../../src/eyepop/worker/worker_options'
+import { PopComponentType, type Pop } from '../../../src/eyepop/worker/worker_types'
 
 import { MockServer } from 'jest-mock-server'
 import { describe, expect, test } from '@jest/globals'
@@ -26,6 +28,13 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
             },
         ],
     }
+    const workerEndpoint = (opts: WorkerOptions) =>
+        new WorkerEndpoint({
+            ...opts,
+            autoStart: opts.autoStart ?? true,
+            stopJobs: opts.stopJobs ?? true,
+            popId: opts.popId === undefined && opts.sessionUuid === undefined ? TransientPopId.Transient : opts.popId,
+        })
 
     test('EyePopSdk connect transient without a pop does not create an empty pipeline', async () => {
         const authenticationRoute = server.post('/v1/auth/authenticate').mockImplementationOnce(ctx => {
@@ -74,7 +83,7 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
             })
         })
 
-        const endpoint = EyePop.workerEndpoint({
+        const endpoint = workerEndpoint({
             eyepopUrl: server.getURL().toString(),
             popId: test_pop_id,
             auth: { apiKey: test_api_key },
@@ -109,7 +118,7 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
             })
         })
 
-        const endpoint = EyePop.workerEndpoint({
+        const endpoint = workerEndpoint({
             eyepopUrl: server.getURL().toString(),
             popId: test_pop_id,
             pop: test_transient_pop,
@@ -138,7 +147,7 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
             })
         })
 
-        const endpoint = EyePop.workerEndpoint({
+        const endpoint = workerEndpoint({
             eyepopUrl: server.getURL().toString(),
             popId: test_pop_id,
             pop: test_transient_pop,
@@ -170,7 +179,7 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
             ])
         })
 
-        const endpoint = EyePop.workerEndpoint({
+        const endpoint = workerEndpoint({
             eyepopUrl: server.getURL().toString(),
             popId: test_pop_id,
             pop: test_transient_pop,
@@ -254,7 +263,7 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
             ctx.status = 204
         })
 
-        const endpoint = EyePop.workerEndpoint({
+        const endpoint = workerEndpoint({
             eyepopUrl: server.getURL().toString(),
             popId: test_pop_id,
             auth: { apiKey: test_api_key },
@@ -360,7 +369,7 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
             ctx.status = 204
         })
 
-        const endpoint = EyePop.workerEndpoint({
+        const endpoint = workerEndpoint({
             eyepopUrl: server.getURL().toString(),
             popId: test_pop_id,
             auth: { apiKey: test_api_key },
@@ -493,7 +502,7 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
             ctx.status = 204
         })
 
-        const endpoint = EyePop.workerEndpoint({
+        const endpoint = workerEndpoint({
             eyepopUrl: server.getURL().toString(),
             popId: test_pop_id,
             pop: test_transient_pop,
@@ -595,7 +604,7 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
             ctx.status = 204
         })
 
-        const endpoint = EyePop.workerEndpoint({
+        const endpoint = workerEndpoint({
             eyepopUrl: server.getURL().toString(),
             popId: test_pop_id,
             sessionName: 'target-smoke-scenario',
@@ -678,7 +687,7 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
             ctx.status = 204
         })
 
-        const endpoint = EyePop.workerEndpoint({
+        const endpoint = workerEndpoint({
             eyepopUrl: server.getURL().toString(),
             popId: test_pop_id,
             pop: test_transient_pop,
@@ -744,7 +753,7 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
             })
         })
 
-        const endpoint = EyePop.workerEndpoint({
+        const endpoint = workerEndpoint({
             eyepopUrl: server.getURL().toString(),
             popId: test_pop_id,
             pop: test_transient_pop,
@@ -815,7 +824,7 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
             })
         })
 
-        const endpoint = EyePop.workerEndpoint({
+        const endpoint = workerEndpoint({
             eyepopUrl: server.getURL().toString(),
             popId: test_pop_id,
             pop: test_transient_pop,
@@ -892,7 +901,7 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
             })
         })
 
-        const endpoint = EyePop.workerEndpoint({
+        const endpoint = workerEndpoint({
             eyepopUrl: server.getURL().toString(),
             popId: test_pop_id,
             pop: test_transient_pop,


### PR DESCRIPTION
## Summary
- Fall back to the caller authorization header when compute sessions omit a session-scoped access token.
- Keep using compute-provided session access tokens when present.
- Bump SDK workspaces to 3.17.2 for patch release.

## Changes
- Updates ComputeSessionClient token selection for worker health checks and subsequent worker calls.
- Adds regression coverage for JWT/caller-token compute sessions without access_token.
- Keeps focused tests from importing the full package index and fixes Auth0 option type inference under current dependency types.

## Test plan
- [x] npm ci
- [x] npx jest --runTestsByPath tests/eyepop/compute/compute_session.test.ts tests/eyepop/worker/endpoint.connect.transient.test.ts --runInBand
- [x] npm run build -w @eyepop.ai/eyepop
- [x] npm test -- --runInBand
- [x] npm run build -ws

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compute session readiness checks when sessions don’t include an access token.
  * Worker health checks now rely on the caller-provided authorization header for tokenless sessions.
  * Resolved session details now correctly handle missing access tokens.

* **Chores**
  * Bumped package versions to 3.17.2.
  * Improved compatibility for browser authentication and local file streaming.
  * Expanded test coverage for tokenless sessions and transient worker connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->