### PR TITLE
[SDK]: Accept accessToken auth alias

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -17,7 +17,7 @@ reviews:
     auto_incremental_review: false
     drafts: false
     labels:
-      - review-ready
+      - needs-review
       - "!skip-review"
       - "!no-review"
       - "!autorelease: pending"

--- a/examples/nextjs/src/app/api/eyepop-session/route.ts
+++ b/examples/nextjs/src/app/api/eyepop-session/route.ts
@@ -8,7 +8,7 @@ export async function GET() {
     }
 
     const endpoint = await EyePop.workerEndpoint({
-        auth: { apiKey },
+        apiKey,
     }).connect()
 
     try {

--- a/examples/nextjs/src/app/page.tsx
+++ b/examples/nextjs/src/app/page.tsx
@@ -30,7 +30,7 @@ export default function Home() {
             const session = await sessionResponse.json()
 
             endpointRef.current = EyePop.workerEndpoint({
-                auth: { session },
+                session,
             })
             await endpointRef.current.connect()
 

--- a/src/eyepop/README.md
+++ b/src/eyepop/README.md
@@ -54,7 +54,6 @@ Create transient sessions with a pop when the worker endpoint is constructed. Th
 
 ```typescript
 import { EyePop } from '@eyepop.ai/eyepop'
-
 ;(async () => {
     const endpoint = await EyePop.workerEndpoint({
         pop: {
@@ -113,7 +112,7 @@ const endpoint = await EyePop.workerEndpoint({
 
 ```typescript
 const endpoint = await EyePop.workerEndpoint({
-    accessToken: process.env.EYEPOP_API_KEY,
+    accessToken: process.env.EYEPOP_ACCESS_TOKEN,
 }).connect()
 ```
 
@@ -130,7 +129,6 @@ export EYEPOP_SESSION_UUID=<your_session_uuid>
 
 ```typescript
 import { EyePop } from '@eyepop.ai/eyepop'
-
 ;(async () => {
     const endpoint = await EyePop.workerEndpoint({
         sessionUuid: process.env.EYEPOP_SESSION_UUID,
@@ -258,10 +256,7 @@ const stream2 = Readable.toWeb(fs.createReadStream('b.jpg'))
 const results = await endpoint.uploadStreamGroup([stream1, stream2], ['image/jpeg', 'image/jpeg'])
 
 // Remote URLs (the server fetches each)
-const results = await endpoint.loadFromGroup([
-    'https://example.com/a.jpg',
-    'https://example.com/b.jpg',
-])
+const results = await endpoint.loadFromGroup(['https://example.com/a.jpg', 'https://example.com/b.jpg'])
 ```
 
 Image order is preserved end-to-end. A group may contain **up to 16 images** (enforced server-side). The pop's ability must be multi-image-capable; a single-image ability handed a group returns an error.

--- a/src/eyepop/README.md
+++ b/src/eyepop/README.md
@@ -105,7 +105,7 @@ You can also pass the key explicitly from server-side configuration:
 
 ```typescript
 const endpoint = await EyePop.workerEndpoint({
-    auth: { apiKey: process.env.EYEPOP_API_KEY },
+    apiKey: process.env.EYEPOP_API_KEY,
 }).connect()
 ```
 
@@ -113,9 +113,11 @@ const endpoint = await EyePop.workerEndpoint({
 
 ```typescript
 const endpoint = await EyePop.workerEndpoint({
-    auth: { accessToken: process.env.EYEPOP_API_KEY },
+    accessToken: process.env.EYEPOP_API_KEY,
 }).connect()
 ```
+
+The nested `auth` option is still supported but deprecated. Pass `apiKey`, `accessToken`, `session`, or `oAuth2` at the top level for new code.
 
 ### Persistent Sessions
 
@@ -183,7 +185,7 @@ Dashboard users can run local browser demos with the current browser session:
 ```html
 <script>
     document.addEventListener('DOMContentLoaded', async () => {
-        const endpoint = await EyePop.workerEndpoint({ auth: { oAuth2: true } }).connect()
+        const endpoint = await EyePop.workerEndpoint({ oAuth2: true }).connect()
         try {
             await endpoint.changePop({
                 components: [

--- a/src/eyepop/README.md
+++ b/src/eyepop/README.md
@@ -109,6 +109,14 @@ const endpoint = await EyePop.workerEndpoint({
 }).connect()
 ```
 
+`accessToken` is accepted as the same bearer credential shape:
+
+```typescript
+const endpoint = await EyePop.workerEndpoint({
+    auth: { accessToken: process.env.EYEPOP_API_KEY },
+}).connect()
+```
+
 ### Persistent Sessions
 
 If EyePop has provisioned a persistent worker session for your deployment, set `EYEPOP_SESSION_UUID` in the trusted server environment or pass `sessionUuid` explicitly.

--- a/src/eyepop/data/data_endpoint.ts
+++ b/src/eyepop/data/data_endpoint.ts
@@ -1,4 +1,4 @@
-import { SessionAuth } from '../options'
+import { SessionAuth, resolveAuth } from '../options'
 import { EndpointState } from '../types'
 import { createWebSocket } from '../shims/websockets'
 import { Endpoint } from '../endpoint'
@@ -92,8 +92,8 @@ export class DataEndpoint extends Endpoint<DataEndpoint> {
         this._accountId = options.accountId || null
         this._account_event_handlers = []
         this._dataset_uuid_to_event_handlers = new Map<string, OnChangeEvent[]>()
-        const sessionAuth: SessionAuth = options.auth as SessionAuth
-        if (sessionAuth.session !== undefined) {
+        const sessionAuth = resolveAuth(options) as SessionAuth | undefined
+        if (sessionAuth?.session !== undefined) {
             const dataSession = sessionAuth.session as DataSession
             if (dataSession.accountId) {
                 this._accountId = dataSession.accountId

--- a/src/eyepop/endpoint.ts
+++ b/src/eyepop/endpoint.ts
@@ -1,4 +1,4 @@
-import { Auth0Options, HttpClient, LocalAuth, OAuth2Auth, Options, SessionAuth, bearerCredential } from './options'
+import { Auth0Options, HttpClient, LocalAuth, OAuth2Auth, Options, SessionAuth, bearerCredential, resolveAuth } from './options'
 import { EndpointState, Session } from './types'
 import { createHttpClient } from './shims/http_client'
 import { Semaphore } from './semaphore'
@@ -115,16 +115,17 @@ export class Endpoint<T extends Endpoint<T>> {
         if (!this._options.eyepopUrl) {
             return Promise.reject('option eyepopUrl or environment variable EYEPOP_URL is required')
         }
-        if (this._options.auth === undefined) {
+        const auth = resolveAuth(this._options)
+        if (auth === undefined) {
             return Promise.reject('cannot connect without defined auth option')
         }
-        const credential = bearerCredential(this._options.auth)
-        if ((this._options.auth as SessionAuth).session !== undefined) {
-            this._token = (this._options.auth as SessionAuth).session.accessToken
-            this._expire_token_time = (this._options.auth as SessionAuth).session.validUntil / 1000
-        } else if ((this._options.auth as OAuth2Auth).oAuth2 !== undefined) {
+        const credential = bearerCredential(auth)
+        if ((auth as SessionAuth).session !== undefined) {
+            this._token = (auth as SessionAuth).session.accessToken
+            this._expire_token_time = (auth as SessionAuth).session.validUntil / 1000
+        } else if ((auth as OAuth2Auth).oAuth2 !== undefined) {
         } else if (credential !== undefined) {
-        } else if ((this._options.auth as LocalAuth).isLocal !== undefined) {
+        } else if ((auth as LocalAuth).isLocal !== undefined) {
         } else {
             return Promise.reject('option apiKey/accessToken or environment variable EYEPOP_API_KEY is required')
         }
@@ -212,7 +213,7 @@ export class Endpoint<T extends Endpoint<T>> {
     }
 
     protected async authorizationHeader(): Promise<string> {
-        if ((this._options.auth as LocalAuth).isLocal !== undefined) {
+        if ((resolveAuth(this._options) as LocalAuth | undefined)?.isLocal !== undefined) {
             return `Implicit`
         }
         return `Bearer ${await this.currentAccessToken()}`
@@ -223,23 +224,24 @@ export class Endpoint<T extends Endpoint<T>> {
         if (!this._token || <number>this._expire_token_time < now) {
             this.updateState(EndpointState.Authenticating)
             try {
+                const auth = resolveAuth(this._options)
                 if (!this._client) {
                     return Promise.reject('endpoint not connected')
-                } else if ((this._options.auth as LocalAuth).isLocal !== undefined) {
-                    this._token = "implicit"
+                } else if ((auth as LocalAuth | undefined)?.isLocal !== undefined) {
+                    this._token = 'implicit'
                     this._expire_token_time = Number.MAX_VALUE
-                } else if ((this._options.auth as SessionAuth).session !== undefined) {
+                } else if ((auth as SessionAuth | undefined)?.session !== undefined) {
                     return Promise.reject('temporary access token expired')
-                } else if ((this._options.auth as OAuth2Auth).oAuth2 !== undefined && this._options.eyepopUrl) {
-                    const session = await authenticateBrowserSession((this._options.auth as OAuth2Auth).oAuth2 as Auth0Options, this._options)
+                } else if ((auth as OAuth2Auth | undefined)?.oAuth2 !== undefined && this._options.eyepopUrl) {
+                    const session = await authenticateBrowserSession((auth as OAuth2Auth).oAuth2 as Auth0Options, this._options)
                     this._token = session.accessToken
                     this._expire_token_time = session.validUntil / 1000
                 } else if (this._options.eyepopUrl) {
-                    const credential = bearerCredential(this._options.auth)
+                    const credential = bearerCredential(auth)
                     if (credential === undefined) {
                         return Promise.reject('no valid auth option')
                     }
-                    const headers = { 'Authorization': `Bearer ${credential}` }
+                    const headers = { Authorization: `Bearer ${credential}` }
                     const post_url = `${this.eyepopUrl()}/v1/auth/authenticate`
                     const response = await this._client.fetch(post_url, {
                         method: 'POST',

--- a/src/eyepop/endpoint.ts
+++ b/src/eyepop/endpoint.ts
@@ -1,4 +1,4 @@
-import { Auth0Options, HttpClient, LocalAuth, OAuth2Auth, Options, SessionAuth, bearerCredential, resolveAuth } from './options'
+import { Auth0Options, HttpClient, LocalAuth, OAuth2Auth, Options, SessionAuth, accessTokenCredential, apiKeyCredential, resolveAuth } from './options'
 import { EndpointState, Session } from './types'
 import { createHttpClient } from './shims/http_client'
 import { Semaphore } from './semaphore'
@@ -119,12 +119,12 @@ export class Endpoint<T extends Endpoint<T>> {
         if (auth === undefined) {
             return Promise.reject('cannot connect without defined auth option')
         }
-        const credential = bearerCredential(auth)
         if ((auth as SessionAuth).session !== undefined) {
             this._token = (auth as SessionAuth).session.accessToken
             this._expire_token_time = (auth as SessionAuth).session.validUntil / 1000
         } else if ((auth as OAuth2Auth).oAuth2 !== undefined) {
-        } else if (credential !== undefined) {
+        } else if (accessTokenCredential(auth) !== undefined) {
+        } else if (apiKeyCredential(auth) !== undefined) {
         } else if ((auth as LocalAuth).isLocal !== undefined) {
         } else {
             return Promise.reject('option apiKey/accessToken or environment variable EYEPOP_API_KEY is required')
@@ -236,8 +236,11 @@ export class Endpoint<T extends Endpoint<T>> {
                     const session = await authenticateBrowserSession((auth as OAuth2Auth).oAuth2 as Auth0Options, this._options)
                     this._token = session.accessToken
                     this._expire_token_time = session.validUntil / 1000
+                } else if (accessTokenCredential(auth) !== undefined) {
+                    this._token = accessTokenCredential(auth) as string
+                    this._expire_token_time = Number.MAX_VALUE
                 } else if (this._options.eyepopUrl) {
-                    const credential = bearerCredential(auth)
+                    const credential = apiKeyCredential(auth)
                     if (credential === undefined) {
                         return Promise.reject('no valid auth option')
                     }

--- a/src/eyepop/endpoint.ts
+++ b/src/eyepop/endpoint.ts
@@ -1,4 +1,4 @@
-import { Auth0Options, HttpClient, LocalAuth, OAuth2Auth, Options, ApiKeyAuth, SessionAuth } from './options'
+import { Auth0Options, HttpClient, LocalAuth, OAuth2Auth, Options, SessionAuth, bearerCredential } from './options'
 import { EndpointState, Session } from './types'
 import { createHttpClient } from './shims/http_client'
 import { Semaphore } from './semaphore'
@@ -118,14 +118,15 @@ export class Endpoint<T extends Endpoint<T>> {
         if (this._options.auth === undefined) {
             return Promise.reject('cannot connect without defined auth option')
         }
+        const credential = bearerCredential(this._options.auth)
         if ((this._options.auth as SessionAuth).session !== undefined) {
             this._token = (this._options.auth as SessionAuth).session.accessToken
             this._expire_token_time = (this._options.auth as SessionAuth).session.validUntil / 1000
         } else if ((this._options.auth as OAuth2Auth).oAuth2 !== undefined) {
-        } else if ((this._options.auth as ApiKeyAuth).apiKey !== undefined) {
+        } else if (credential !== undefined) {
         } else if ((this._options.auth as LocalAuth).isLocal !== undefined) {
         } else {
-            return Promise.reject('option apiKey or environment variable EYEPOP_API_KEY is required')
+            return Promise.reject('option apiKey/accessToken or environment variable EYEPOP_API_KEY is required')
         }
 
         if (this._options.platformSupport?.createHttpClient !== undefined) {
@@ -233,8 +234,12 @@ export class Endpoint<T extends Endpoint<T>> {
                     const session = await authenticateBrowserSession((this._options.auth as OAuth2Auth).oAuth2 as Auth0Options, this._options)
                     this._token = session.accessToken
                     this._expire_token_time = session.validUntil / 1000
-                } else if ((this._options.auth as ApiKeyAuth).apiKey !== undefined && this._options.eyepopUrl) {
-                    const headers = { 'Authorization': `Bearer ${(this._options.auth as ApiKeyAuth).apiKey}` }
+                } else if (this._options.eyepopUrl) {
+                    const credential = bearerCredential(this._options.auth)
+                    if (credential === undefined) {
+                        return Promise.reject('no valid auth option')
+                    }
+                    const headers = { 'Authorization': `Bearer ${credential}` }
                     const post_url = `${this.eyepopUrl()}/v1/auth/authenticate`
                     const response = await this._client.fetch(post_url, {
                         method: 'POST',

--- a/src/eyepop/index.ts
+++ b/src/eyepop/index.ts
@@ -1,4 +1,4 @@
-import { AccessTokenAuth, ApiKeyAuth, LocalAuth, OAuth2Auth, Options, SessionAuth } from './options'
+import { AccessTokenAuth, ApiKeyAuth, LocalAuth, OAuth2Auth, Options, SessionAuth, resolveAuth } from './options'
 
 import { WorkerEndpoint } from './worker/worker_endpoint'
 import { DataEndpoint } from './data/data_endpoint'
@@ -170,11 +170,11 @@ export namespace EyePop {
             opts.eyepopUrl = 'http://127.0.0.1:8080'
         }
         _fill_default_options(opts)
-        if (opts.auth === undefined) {
+        if (resolveAuth(opts) === undefined) {
             if (opts.isLocalMode) {
                 opts.auth = { isLocal: true } as LocalAuth
             } else {
-                throw new Error('auth option or EYEPOP_API_KEY environment variable is required')
+                throw new Error('apiKey/accessToken/session/oAuth2 option or EYEPOP_API_KEY environment variable is required')
             }
         }
 
@@ -204,11 +204,12 @@ export namespace EyePop {
             opts.stopJobs = true
         }
 
-        if (opts.auth !== undefined) {
-            if ((opts.auth as SessionAuth).session !== undefined) {
-                if (((opts.auth as SessionAuth).session as WorkerSession) !== undefined) {
-                    if (((opts.auth as SessionAuth).session as WorkerSession).popId) {
-                        opts.popId = ((opts.auth as SessionAuth).session as WorkerSession).popId
+        const auth = resolveAuth(opts)
+        if (auth !== undefined) {
+            if ((auth as SessionAuth).session !== undefined) {
+                if (((auth as SessionAuth).session as WorkerSession) !== undefined) {
+                    if (((auth as SessionAuth).session as WorkerSession).popId) {
+                        opts.popId = ((auth as SessionAuth).session as WorkerSession).popId
                     }
                 }
             }
@@ -218,16 +219,17 @@ export namespace EyePop {
 
     export function dataEndpoint(opts: DataOptions = {}): DataEndpoint {
         _fill_default_options(opts)
-        if (opts.auth === undefined) {
-            throw new Error('auth option or EYEPOP_API_KEY environment variable is required')
+        const auth = resolveAuth(opts)
+        if (auth === undefined) {
+            throw new Error('apiKey/accessToken/session/oAuth2 option or EYEPOP_API_KEY environment variable is required')
         }
         if (opts.accountId === undefined) {
             opts.accountId = readEnv('EYEPOP_ACCOUNT_ID')
         }
-        if ((opts.auth as SessionAuth).session !== undefined) {
-            if (((opts.auth as SessionAuth).session as DataSession) !== undefined) {
-                if (((opts.auth as SessionAuth).session as DataSession).accountId) {
-                    opts.accountId = ((opts.auth as SessionAuth).session as DataSession).accountId
+        if ((auth as SessionAuth).session !== undefined) {
+            if (((auth as SessionAuth).session as DataSession) !== undefined) {
+                if (((auth as SessionAuth).session as DataSession).accountId) {
+                    opts.accountId = ((auth as SessionAuth).session as DataSession).accountId
                 }
             }
         }
@@ -235,13 +237,13 @@ export namespace EyePop {
     }
 
     function _fill_default_options(opts: Options) {
-        if (!opts.auth) {
-            opts.auth = defaultAuth
+        if (resolveAuth(opts) === undefined && defaultAuth) {
+            opts.apiKey = defaultAuth.apiKey
         }
 
-        if (!opts.eyepopUrl && opts.auth && (opts.auth as SessionAuth).session && (opts.auth as SessionAuth).session.eyepopUrl) {
-            // Pre-authenticated browser session may overwrite eyepopUrl
-            opts.eyepopUrl = (opts.auth as SessionAuth).session.eyepopUrl
+        const auth = resolveAuth(opts)
+        if (!opts.eyepopUrl && auth && (auth as SessionAuth).session && (auth as SessionAuth).session.eyepopUrl) {
+            opts.eyepopUrl = (auth as SessionAuth).session.eyepopUrl
         }
 
         if (!opts.eyepopUrl) {
@@ -252,27 +254,31 @@ export namespace EyePop {
             opts.eyepopUrl = 'https://compute.eyepop.ai'
         }
 
-        if (opts.auth) {
-            if ((opts.auth as OAuth2Auth).oAuth2 !== undefined) {
-                if (typeof (opts.auth as OAuth2Auth).oAuth2 === 'boolean') {
-                    if (opts.eyepopUrl && opts.eyepopUrl.match(/https:(.*).staging.eyepop.xyz/i)) {
-                        opts.auth = {
-                            oAuth2: {
-                                domain: 'dev-eyepop.us.auth0.com',
-                                clientId: 'jktx3YO2UnbkNPvr05PQWf26t1kNTJyg',
-                                audience: 'https://dev-app.eyepop.ai',
-                                scope: 'admin:clouds access:inference-api access:datasets',
-                            },
-                        }
+        if (auth) {
+            if ((auth as OAuth2Auth).oAuth2 !== undefined) {
+                if (typeof (auth as OAuth2Auth).oAuth2 === 'boolean') {
+                    const oAuth2: OAuth2Auth =
+                        opts.eyepopUrl && opts.eyepopUrl.match(/https:(.*).staging.eyepop.xyz/i)
+                            ? {
+                                  oAuth2: {
+                                      domain: 'dev-eyepop.us.auth0.com',
+                                      clientId: 'jktx3YO2UnbkNPvr05PQWf26t1kNTJyg',
+                                      audience: 'https://dev-app.eyepop.ai',
+                                      scope: 'admin:clouds access:inference-api access:datasets',
+                                  },
+                              }
+                            : {
+                                  oAuth2: {
+                                      domain: 'eyepop.us.auth0.com',
+                                      clientId: 'Lb9ubA9Hf3jlaqWLUx8XgA0zvotgViCl',
+                                      audience: 'https://api.eyepop.ai',
+                                      scope: 'admin:clouds access:inference-api access:datasets',
+                                  },
+                              }
+                    if (opts.oAuth2 !== undefined) {
+                        opts.oAuth2 = oAuth2.oAuth2
                     } else {
-                        opts.auth = {
-                            oAuth2: {
-                                domain: 'eyepop.us.auth0.com',
-                                clientId: 'Lb9ubA9Hf3jlaqWLUx8XgA0zvotgViCl',
-                                audience: 'https://api.eyepop.ai',
-                                scope: 'admin:clouds access:inference-api access:datasets',
-                            },
-                        }
+                        opts.auth = oAuth2
                     }
                 }
             }

--- a/src/eyepop/index.ts
+++ b/src/eyepop/index.ts
@@ -1,4 +1,4 @@
-import { ApiKeyAuth, LocalAuth, OAuth2Auth, Options, SessionAuth } from './options'
+import { AccessTokenAuth, ApiKeyAuth, LocalAuth, OAuth2Auth, Options, SessionAuth } from './options'
 
 import { WorkerEndpoint } from './worker/worker_endpoint'
 import { DataEndpoint } from './data/data_endpoint'
@@ -125,7 +125,7 @@ export {
     DEFAULT_PREDICTION_VERSION,
 } from './worker/worker_types'
 
-export { Options, Authentication, SessionAuth, ApiKeyAuth, OAuth2Auth, Auth0Options, HttpClient, PlatformSupport, LocalAuth } from './options'
+export { Options, Authentication, SessionAuth, ApiKeyAuth, AccessTokenAuth, OAuth2Auth, Auth0Options, HttpClient, PlatformSupport, LocalAuth } from './options'
 
 export { DataOptions } from './data/data_options'
 

--- a/src/eyepop/options.ts
+++ b/src/eyepop/options.ts
@@ -63,13 +63,16 @@ export function resolveAuth(options: Options): Authentication {
     return options.auth
 }
 
-export function bearerCredential(auth: Authentication): string | undefined {
+export function apiKeyCredential(auth: Authentication): string | undefined {
     if (auth === undefined) {
         return undefined
     }
-    const apiKey = (auth as ApiKeyAuth).apiKey
-    if (apiKey !== undefined) {
-        return apiKey
+    return (auth as ApiKeyAuth).apiKey
+}
+
+export function accessTokenCredential(auth: Authentication): string | undefined {
+    if (auth === undefined) {
+        return undefined
     }
     return (auth as AccessTokenAuth).accessToken
 }

--- a/src/eyepop/options.ts
+++ b/src/eyepop/options.ts
@@ -47,6 +47,22 @@ export interface LocalAuth {
 
 export type Authentication = undefined | ApiKeyAuth | AccessTokenAuth | SessionAuth | OAuth2Auth | LocalAuth
 
+export function resolveAuth(options: Options): Authentication {
+    if (options.apiKey !== undefined) {
+        return { apiKey: options.apiKey }
+    }
+    if (options.accessToken !== undefined) {
+        return { accessToken: options.accessToken }
+    }
+    if (options.session !== undefined) {
+        return { session: options.session }
+    }
+    if (options.oAuth2 !== undefined) {
+        return { oAuth2: options.oAuth2 }
+    }
+    return options.auth
+}
+
 export function bearerCredential(auth: Authentication): string | undefined {
     if (auth === undefined) {
         return undefined
@@ -70,6 +86,30 @@ export interface PlatformSupport {
 }
 
 export interface Options {
+    /**
+     * Authentication api key for server side execution.
+     * Defaults to process.env['EYEPOP_API_KEY'].
+     */
+    apiKey?: string | undefined
+
+    /**
+     * Bearer token accepted by the compute API.
+     */
+    accessToken?: string | undefined
+
+    /**
+     * Temporary authentication token for client side execution.
+     */
+    session?: Session | undefined
+
+    /**
+     * For development mode, authenticate with your dashboard.eyepop.ai account
+     */
+    oAuth2?: true | Auth0Options | undefined
+
+    /**
+     * @deprecated Pass apiKey, accessToken, session, or oAuth2 at the top level.
+     */
     auth?: Authentication | undefined
 
     eyepopUrl?: string | undefined

--- a/src/eyepop/options.ts
+++ b/src/eyepop/options.ts
@@ -17,6 +17,13 @@ export interface ApiKeyAuth {
     apiKey: string
 }
 
+export interface AccessTokenAuth {
+    /**
+     * Bearer token accepted by the compute API.
+     */
+    accessToken: string
+}
+
 export interface SessionAuth {
     /**
      * Temporary authentication token for client side execution.
@@ -38,7 +45,18 @@ export interface LocalAuth {
     isLocal: true
 }
 
-export type Authentication = undefined | ApiKeyAuth | SessionAuth | OAuth2Auth | LocalAuth
+export type Authentication = undefined | ApiKeyAuth | AccessTokenAuth | SessionAuth | OAuth2Auth | LocalAuth
+
+export function bearerCredential(auth: Authentication): string | undefined {
+    if (auth === undefined) {
+        return undefined
+    }
+    const apiKey = (auth as ApiKeyAuth).apiKey
+    if (apiKey !== undefined) {
+        return apiKey
+    }
+    return (auth as AccessTokenAuth).accessToken
+}
 
 export interface HttpClient {
     fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>

--- a/src/eyepop/options.ts
+++ b/src/eyepop/options.ts
@@ -47,12 +47,18 @@ export interface LocalAuth {
 
 export type Authentication = undefined | ApiKeyAuth | AccessTokenAuth | SessionAuth | OAuth2Auth | LocalAuth
 
+function nonEmptyCredential(value: string | undefined): string | undefined {
+    return value && value.length > 0 ? value : undefined
+}
+
 export function resolveAuth(options: Options): Authentication {
-    if (options.apiKey !== undefined) {
-        return { apiKey: options.apiKey }
+    const apiKey = nonEmptyCredential(options.apiKey)
+    if (apiKey !== undefined) {
+        return { apiKey }
     }
-    if (options.accessToken !== undefined) {
-        return { accessToken: options.accessToken }
+    const accessToken = nonEmptyCredential(options.accessToken)
+    if (accessToken !== undefined) {
+        return { accessToken }
     }
     if (options.session !== undefined) {
         return { session: options.session }
@@ -67,14 +73,14 @@ export function apiKeyCredential(auth: Authentication): string | undefined {
     if (auth === undefined) {
         return undefined
     }
-    return (auth as ApiKeyAuth).apiKey
+    return nonEmptyCredential((auth as ApiKeyAuth).apiKey)
 }
 
 export function accessTokenCredential(auth: Authentication): string | undefined {
     if (auth === undefined) {
         return undefined
     }
-    return (auth as AccessTokenAuth).accessToken
+    return nonEmptyCredential((auth as AccessTokenAuth).accessToken)
 }
 
 export interface HttpClient {

--- a/src/eyepop/worker/worker_endpoint.ts
+++ b/src/eyepop/worker/worker_endpoint.ts
@@ -1,4 +1,4 @@
-import { LocalAuth, bearerCredential, resolveAuth } from '../options'
+import { LocalAuth, accessTokenCredential, apiKeyCredential, resolveAuth } from '../options'
 import { ComputeSessionClient } from '../compute/compute_session'
 import type { ResolvedComputeSession } from '../compute/compute_session'
 import { EndpointState, Session } from '../types'
@@ -261,18 +261,16 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
                         streamSource = await resolvePath({ path }, this._logger)
                     }
                     return { stream: streamSource.stream, mimeType: streamSource.mimeType }
-                })
+                }),
             )
-            const job = new UploadGroupJob(
-                sources,
-                params,
-                async () => this.session(),
-                this._client,
-                this._requestLogger,
-            )
+            const job = new UploadGroupJob(sources, params, async () => this.session(), this._client, this._requestLogger)
             return job.start(
-                () => { this.jobDone(job) },
-                (statusCode: number) => { this.jobStatus(job, statusCode) },
+                () => {
+                    this.jobDone(job)
+                },
+                (statusCode: number) => {
+                    this.jobStatus(job, statusCode)
+                },
             )
         } catch (e) {
             this._limit.release()
@@ -280,11 +278,7 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
         }
     }
 
-    public async uploadStreamGroup(
-        streams: Array<ReadableStream<Uint8Array> | Blob | BufferSource>,
-        mimeTypes?: string[],
-        params: ProcessParams = {}
-    ): Promise<ResultStream> {
+    public async uploadStreamGroup(streams: Array<ReadableStream<Uint8Array> | Blob | BufferSource>, mimeTypes?: string[], params: ProcessParams = {}): Promise<ResultStream> {
         if (streams.length === 0) {
             throw new Error('upload stream group requires at least one stream')
         }
@@ -301,16 +295,14 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
                 stream,
                 mimeType: mimeTypes?.[i] ?? null,
             }))
-            const job = new UploadGroupJob(
-                sources,
-                params,
-                async () => this.session(),
-                this._client,
-                this._requestLogger,
-            )
+            const job = new UploadGroupJob(sources, params, async () => this.session(), this._client, this._requestLogger)
             return job.start(
-                () => { this.jobDone(job) },
-                (statusCode: number) => { this.jobStatus(job, statusCode) },
+                () => {
+                    this.jobDone(job)
+                },
+                (statusCode: number) => {
+                    this.jobStatus(job, statusCode)
+                },
             )
         } catch (e) {
             this._limit.release()
@@ -328,16 +320,14 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
         await this._limit.acquire()
         try {
             this.updateState()
-            const job = new LoadFromGroupJob(
-                urls,
-                params,
-                async () => this.session(),
-                this._client,
-                this._requestLogger,
-            )
+            const job = new LoadFromGroupJob(urls, params, async () => this.session(), this._client, this._requestLogger)
             return job.start(
-                () => { this.jobDone(job) },
-                (statusCode: number) => { this.jobStatus(job, statusCode) },
+                () => {
+                    this.jobDone(job)
+                },
+                (statusCode: number) => {
+                    this.jobStatus(job, statusCode)
+                },
             )
         } catch (e) {
             this._limit.release()
@@ -876,7 +866,7 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
         if ((auth as LocalAuth | undefined)?.isLocal !== undefined) {
             return 'Implicit'
         }
-        const credential = bearerCredential(auth)
+        const credential = apiKeyCredential(auth) ?? accessTokenCredential(auth)
         if (credential !== undefined) {
             return `Bearer ${credential}`
         }
@@ -894,5 +884,4 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
             }
         }
     }
-
 }

--- a/src/eyepop/worker/worker_endpoint.ts
+++ b/src/eyepop/worker/worker_endpoint.ts
@@ -1,4 +1,4 @@
-import { ApiKeyAuth, LocalAuth } from '../options'
+import { LocalAuth, bearerCredential } from '../options'
 import { ComputeSessionClient } from '../compute/compute_session'
 import type { ResolvedComputeSession } from '../compute/compute_session'
 import { EndpointState, Session } from '../types'
@@ -875,8 +875,9 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
         if ((this.options().auth as LocalAuth).isLocal !== undefined) {
             return 'Implicit'
         }
-        if ((this.options().auth as ApiKeyAuth).apiKey !== undefined) {
-            return `Bearer ${(this.options().auth as ApiKeyAuth).apiKey}`
+        const credential = bearerCredential(this.options().auth)
+        if (credential !== undefined) {
+            return `Bearer ${credential}`
         }
         return super.authorizationHeader()
     }

--- a/src/eyepop/worker/worker_endpoint.ts
+++ b/src/eyepop/worker/worker_endpoint.ts
@@ -1,4 +1,4 @@
-import { LocalAuth, bearerCredential } from '../options'
+import { LocalAuth, bearerCredential, resolveAuth } from '../options'
 import { ComputeSessionClient } from '../compute/compute_session'
 import type { ResolvedComputeSession } from '../compute/compute_session'
 import { EndpointState, Session } from '../types'
@@ -168,7 +168,7 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
     }
 
     private _authenticationHeaders(session: Session): any {
-        return (this._options.auth as LocalAuth).isLocal !== undefined ? {} : { Authorization: `Bearer ${session.accessToken}` }
+        return (resolveAuth(this._options) as LocalAuth | undefined)?.isLocal !== undefined ? {} : { Authorization: `Bearer ${session.accessToken}` }
     }
 
     /**
@@ -872,10 +872,11 @@ export class WorkerEndpoint extends Endpoint<WorkerEndpoint> {
     }
 
     private async computeAuthorizationHeader(): Promise<string> {
-        if ((this.options().auth as LocalAuth).isLocal !== undefined) {
+        const auth = resolveAuth(this.options())
+        if ((auth as LocalAuth | undefined)?.isLocal !== undefined) {
             return 'Implicit'
         }
-        const credential = bearerCredential(this.options().auth)
+        const credential = bearerCredential(auth)
         if (credential !== undefined) {
             return `Bearer ${credential}`
         }

--- a/tests/eyepop/data/endpoint.connect.test.ts
+++ b/tests/eyepop/data/endpoint.connect.test.ts
@@ -57,6 +57,34 @@ describe('EyePopSdk endpoint module auth and connect', () => {
         }
     })
 
+    test('EyePopSdk connect uses accessToken directly', async () => {
+        const authenticationRoute = server.post('/v1/auth/authenticate').mockImplementationOnce(ctx => {
+            ctx.status = 500
+        })
+
+        const dataConfigRoute = server.get(`/v1/configs`).mockImplementationOnce(ctx => {
+            expect(ctx.headers.authorization).toBe(`Bearer ${test_access_token}`)
+            ctx.status = 200
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify({ dataset_api_url: `${server.getURL()}data/` })
+        })
+
+        const endpoint = EyePop.dataEndpoint({
+            eyepopUrl: server.getURL().toString(),
+            accountId: test_account_id,
+            accessToken: test_access_token,
+            disableWs: true,
+        })
+        expect(endpoint).toBeDefined()
+        try {
+            await endpoint.connect()
+            expect(authenticationRoute).toHaveBeenCalledTimes(0)
+            expect(dataConfigRoute).toHaveBeenCalledTimes(1)
+        } finally {
+            await endpoint.disconnect()
+        }
+    })
+
     test('EyePopSdk reuse token', async () => {
         const test_access_token = uuidv4()
         const long_token_valid_time = 1000 * 1000

--- a/tests/eyepop/data/endpoint.connect.test.ts
+++ b/tests/eyepop/data/endpoint.connect.test.ts
@@ -44,7 +44,7 @@ describe('EyePopSdk endpoint module auth and connect', () => {
         const endpoint = EyePop.dataEndpoint({
             eyepopUrl: server.getURL().toString(),
             accountId: test_account_id,
-            auth: { apiKey: test_api_key },
+            apiKey: test_api_key,
             disableWs: true,
         })
         expect(endpoint).toBeDefined()

--- a/tests/eyepop/worker/endpoint.connect.test.ts
+++ b/tests/eyepop/worker/endpoint.connect.test.ts
@@ -64,6 +64,48 @@ describe('EyePopSdk endpoint module auth and connect', () => {
         }
     })
 
+    test('EyePopSdk connect uses accessToken directly', async () => {
+        const authenticationRoute = server.post('/v1/auth/authenticate').mockImplementationOnce(ctx => {
+            ctx.status = 500
+        })
+
+        const popConfigRoute = server.get(`/pops/${test_pop_id}/config`).mockImplementationOnce(ctx => {
+            expect(ctx.headers.authorization).toBe(`Bearer ${test_access_token}`)
+            ctx.status = 200
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify({ base_url: `${server.getURL()}worker/`, pipeline_id: test_pipeline_id })
+        })
+
+        const stopRoute = server.patch(`/worker/pipelines/${test_pipeline_id}/source`).mockImplementationOnce(ctx => {
+            ctx.status = 204
+        })
+
+        const getPipelineRoute = server.get(`/worker/pipelines/${test_pipeline_id}`).mockImplementationOnce(ctx => {
+            expect(ctx.headers.authorization).toBe(`Bearer ${test_access_token}`)
+            ctx.status = 200
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify({
+                id: test_pipeline_id,
+            })
+        })
+
+        const endpoint = EyePop.workerEndpoint({
+            eyepopUrl: server.getURL().toString(),
+            popId: test_pop_id,
+            accessToken: test_access_token,
+        })
+        expect(endpoint).toBeDefined()
+        try {
+            await endpoint.connect()
+            expect(authenticationRoute).toHaveBeenCalledTimes(0)
+            expect(popConfigRoute).toHaveBeenCalledTimes(1)
+            expect(stopRoute).toHaveBeenCalledTimes(1)
+            expect(getPipelineRoute).toHaveBeenCalledTimes(1)
+        } finally {
+            await endpoint.disconnect()
+        }
+    })
+
     test('EyePopSdk reuse token', async () => {
         const test_pop_id = uuidv4()
         const test_pipeline_id = uuidv4()

--- a/tests/eyepop/worker/endpoint.connect.test.ts
+++ b/tests/eyepop/worker/endpoint.connect.test.ts
@@ -293,7 +293,7 @@ describe('EyePopSdk endpoint module auth and connect', () => {
             eyepopUrl: server.getURL().toString(),
             popId: test_pop_id,
             stopJobs: false,
-            auth: { session: session },
+            session,
         })
         expect(endpoint2).toBeDefined()
 

--- a/tests/eyepop/worker/endpoint.connect.transient.test.ts
+++ b/tests/eyepop/worker/endpoint.connect.transient.test.ts
@@ -160,6 +160,111 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
         }
     })
 
+    test('EyePopSdk connect transient preserves deprecated nested apiKey auth', async () => {
+        const listSessionsRoute = server.get(`/v1/sessions`).mockImplementationOnce(ctx => {
+            expect(ctx.headers.authorization).toBe(`Bearer ${test_api_key}`)
+            ctx.status = 404
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify('no sessions')
+        })
+
+        const createSessionRoute = server.post(`/v1/sessions`).mockImplementationOnce(ctx => {
+            expect(ctx.headers.authorization).toBe(`Bearer ${test_api_key}`)
+            ctx.status = 200
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify([
+                {
+                    session_uuid: test_session_uuid,
+                    session_endpoint: `${server.getURL().toString()}${test_session_uuid}`,
+                    access_token: test_access_token,
+                    access_token_expires_in: long_token_valid_time,
+                    pipelines: [],
+                    session_status: 'running',
+                    session_active: true,
+                },
+            ])
+        })
+
+        const healthRoute = server.get(`/${test_session_uuid}/health`).mockImplementation(ctx => {
+            ctx.status = 200
+            ctx.response.headers['content-type'] = 'text/plain'
+            ctx.body = "I'm fine"
+        })
+
+        const endpoint = workerEndpoint({
+            eyepopUrl: server.getURL().toString(),
+            popId: test_pop_id,
+            auth: { apiKey: test_api_key },
+        })
+        expect(endpoint).toBeDefined()
+        try {
+            await endpoint.connect()
+            expect(listSessionsRoute).toHaveBeenCalledTimes(1)
+            expect(createSessionRoute).toHaveBeenCalledTimes(1)
+            expect(healthRoute).toHaveBeenCalledTimes(1)
+        } finally {
+            await endpoint.disconnect()
+        }
+    })
+
+    test('EyePopSdk connect transient preserves deprecated nested accessToken auth', async () => {
+        const authenticationRoute = server.post('/v1/auth/authenticate').mockImplementationOnce(ctx => {
+            ctx.status = 200
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify({
+                access_token: test_access_token,
+                expires_in: long_token_valid_time,
+                token_type: 'Bearer',
+            })
+        })
+
+        const listSessionsRoute = server.get(`/v1/sessions`).mockImplementationOnce(ctx => {
+            expect(ctx.headers.authorization).toBe(`Bearer ${test_access_token}`)
+            ctx.status = 404
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify('no sessions')
+        })
+
+        const createSessionRoute = server.post(`/v1/sessions`).mockImplementationOnce(ctx => {
+            expect(ctx.headers.authorization).toBe(`Bearer ${test_access_token}`)
+            ctx.status = 200
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify([
+                {
+                    session_uuid: test_session_uuid,
+                    session_endpoint: `${server.getURL().toString()}${test_session_uuid}`,
+                    access_token: test_access_token,
+                    access_token_expires_in: long_token_valid_time,
+                    pipelines: [],
+                    session_status: 'running',
+                    session_active: true,
+                },
+            ])
+        })
+
+        const healthRoute = server.get(`/${test_session_uuid}/health`).mockImplementation(ctx => {
+            ctx.status = 200
+            ctx.response.headers['content-type'] = 'text/plain'
+            ctx.body = "I'm fine"
+        })
+
+        const endpoint = workerEndpoint({
+            eyepopUrl: server.getURL().toString(),
+            popId: test_pop_id,
+            auth: { accessToken: test_access_token },
+        })
+        expect(endpoint).toBeDefined()
+        try {
+            await endpoint.connect()
+            expect(authenticationRoute).toHaveBeenCalledTimes(0)
+            expect(listSessionsRoute).toHaveBeenCalledTimes(1)
+            expect(createSessionRoute).toHaveBeenCalledTimes(1)
+            expect(healthRoute).toHaveBeenCalledTimes(1)
+        } finally {
+            await endpoint.disconnect()
+        }
+    })
+
     test('EyePopSdk connect transient reports compute pipeline errors', async () => {
         server.get(`/v1/sessions`).mockImplementationOnce(ctx => {
             ctx.status = 404

--- a/tests/eyepop/worker/endpoint.connect.transient.test.ts
+++ b/tests/eyepop/worker/endpoint.connect.transient.test.ts
@@ -160,6 +160,54 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
         }
     })
 
+    test('EyePopSdk connect transient ignores blank top-level apiKey when accessToken is set', async () => {
+        const listSessionsRoute = server.get(`/v1/sessions`).mockImplementationOnce(ctx => {
+            expect(ctx.headers.authorization).toBe(`Bearer ${test_access_token}`)
+            ctx.status = 404
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify('no sessions')
+        })
+
+        const createSessionRoute = server.post(`/v1/sessions`).mockImplementationOnce(ctx => {
+            expect(ctx.headers.authorization).toBe(`Bearer ${test_access_token}`)
+            ctx.status = 200
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify([
+                {
+                    session_uuid: test_session_uuid,
+                    session_endpoint: `${server.getURL().toString()}${test_session_uuid}`,
+                    access_token: test_access_token,
+                    access_token_expires_in: long_token_valid_time,
+                    pipelines: [],
+                    session_status: 'running',
+                    session_active: true,
+                },
+            ])
+        })
+
+        const healthRoute = server.get(`/${test_session_uuid}/health`).mockImplementation(ctx => {
+            ctx.status = 200
+            ctx.response.headers['content-type'] = 'text/plain'
+            ctx.body = "I'm fine"
+        })
+
+        const endpoint = workerEndpoint({
+            eyepopUrl: server.getURL().toString(),
+            popId: test_pop_id,
+            apiKey: '',
+            accessToken: test_access_token,
+        })
+        expect(endpoint).toBeDefined()
+        try {
+            await endpoint.connect()
+            expect(listSessionsRoute).toHaveBeenCalledTimes(1)
+            expect(createSessionRoute).toHaveBeenCalledTimes(1)
+            expect(healthRoute).toHaveBeenCalledTimes(1)
+        } finally {
+            await endpoint.disconnect()
+        }
+    })
+
     test('EyePopSdk connect transient preserves deprecated nested apiKey auth', async () => {
         const listSessionsRoute = server.get(`/v1/sessions`).mockImplementationOnce(ctx => {
             expect(ctx.headers.authorization).toBe(`Bearer ${test_api_key}`)

--- a/tests/eyepop/worker/endpoint.connect.transient.test.ts
+++ b/tests/eyepop/worker/endpoint.connect.transient.test.ts
@@ -54,6 +54,7 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
         })
 
         const createSessionRoute = server.post(`/v1/sessions`).mockImplementationOnce(ctx => {
+            expect(ctx.headers.authorization).toBe(`Bearer ${test_api_key}`)
             ctx.status = 200
             ctx.response.headers['content-type'] = 'application/json'
             ctx.body = JSON.stringify([
@@ -96,6 +97,64 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
             expect(createSessionRoute).toHaveBeenCalledTimes(1)
             expect(healthRoute).toHaveBeenCalledTimes(1)
             expect(startPipelineRoute).toHaveBeenCalledTimes(0)
+        } finally {
+            await endpoint.disconnect()
+        }
+    })
+
+    test('EyePopSdk connect transient accepts accessToken auth as compute bearer', async () => {
+        const authenticationRoute = server.post('/v1/auth/authenticate').mockImplementationOnce(ctx => {
+            ctx.status = 200
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify({
+                access_token: test_access_token,
+                expires_in: long_token_valid_time,
+                token_type: 'Bearer',
+            })
+        })
+
+        const listSessionsRoute = server.get(`/v1/sessions`).mockImplementationOnce(ctx => {
+            expect(ctx.headers.authorization).toBe(`Bearer ${test_access_token}`)
+            ctx.status = 404
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify('no sessions')
+        })
+
+        const createSessionRoute = server.post(`/v1/sessions`).mockImplementationOnce(ctx => {
+            expect(ctx.headers.authorization).toBe(`Bearer ${test_access_token}`)
+            ctx.status = 200
+            ctx.response.headers['content-type'] = 'application/json'
+            ctx.body = JSON.stringify([
+                {
+                    session_uuid: test_session_uuid,
+                    session_endpoint: `${server.getURL().toString()}${test_session_uuid}`,
+                    access_token: test_access_token,
+                    access_token_expires_in: long_token_valid_time,
+                    pipelines: [],
+                    session_status: 'running',
+                    session_active: true,
+                },
+            ])
+        })
+
+        const healthRoute = server.get(`/${test_session_uuid}/health`).mockImplementation(ctx => {
+            ctx.status = 200
+            ctx.response.headers['content-type'] = 'text/plain'
+            ctx.body = "I'm fine"
+        })
+
+        const endpoint = workerEndpoint({
+            eyepopUrl: server.getURL().toString(),
+            popId: test_pop_id,
+            auth: { accessToken: test_access_token },
+        })
+        expect(endpoint).toBeDefined()
+        try {
+            await endpoint.connect()
+            expect(authenticationRoute).toHaveBeenCalledTimes(0)
+            expect(listSessionsRoute).toHaveBeenCalledTimes(1)
+            expect(createSessionRoute).toHaveBeenCalledTimes(1)
+            expect(healthRoute).toHaveBeenCalledTimes(1)
         } finally {
             await endpoint.disconnect()
         }

--- a/tests/eyepop/worker/endpoint.connect.transient.test.ts
+++ b/tests/eyepop/worker/endpoint.connect.transient.test.ts
@@ -87,7 +87,7 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
         const endpoint = workerEndpoint({
             eyepopUrl: server.getURL().toString(),
             popId: test_pop_id,
-            auth: { apiKey: test_api_key },
+            apiKey: test_api_key,
         })
         expect(endpoint).toBeDefined()
         try {
@@ -146,7 +146,7 @@ describe('EyePopSdk endpoint module auth and connect for transient popId', () =>
         const endpoint = workerEndpoint({
             eyepopUrl: server.getURL().toString(),
             popId: test_pop_id,
-            auth: { accessToken: test_access_token },
+            accessToken: test_access_token,
         })
         expect(endpoint).toBeDefined()
         try {


### PR DESCRIPTION
## Summary
- Add `auth.accessToken` as a first-class bearer auth option alongside `auth.apiKey`.
- Route both names through the same compute bearer credential path.
- Document the alias and cover transient compute session auth with a focused test.

## Test plan
- [x] `git diff --check`
- [x] Verified no `secretKey`, `secret_key`, or `EYEPOP_SECRET_KEY` references remain in SDK source/examples/tests/scripts.
- [ ] GitHub CI

Notes: local dependency install/tests were not run from this worktree; we are using GitHub CI for SDK checks.