### PR TITLE
[SDK]: Release 3.17.3

### DIFF
--- a/src/eyepop-render-2d/package.json
+++ b/src/eyepop-render-2d/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@eyepop.ai/eyepop-render-2d",
-    "version": "3.17.2",
+    "version": "3.17.3",
     "description": "The Node.js / Typescript library for 2d rendering of EyePop.ai's inference API",
     "keywords": [
         "AI",
@@ -36,7 +36,7 @@
         "dev": "tsup && webpack; npx chokidar '**/*.ts' -i 'dist' -c 'npx tsup && webpack'"
     },
     "dependencies": {
-        "@eyepop.ai/eyepop": "3.17.2",
+        "@eyepop.ai/eyepop": "3.17.3",
         "@juggle/resize-observer": "^3.4.0",
         "@types/jsonpath": "^0.2.4",
         "canvas": "3.2.0",

--- a/src/eyepop/package.json
+++ b/src/eyepop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@eyepop.ai/eyepop",
-    "version": "3.17.2",
+    "version": "3.17.3",
     "description": "The official Node.js / Typescript library for EyePop.ai's inference API",
     "keywords": [
         "AI",

--- a/src/react-native-eyepop/package.json
+++ b/src/react-native-eyepop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eyepop.ai/react-native-eyepop",
-  "version": "3.17.2",
+  "version": "3.17.3",
   "description": "The official Typescript library for EyePop.ai's inference API for React Native",
   "source": "./src/index.ts",
   "main": "./lib/commonjs/index.js",
@@ -68,8 +68,8 @@
   },
   "dependencies": {
     "@azure/core-asynciterator-polyfill": "^1.0.2",
-    "@eyepop.ai/eyepop": "3.17.2",
-    "@eyepop.ai/eyepop-render-2d": "3.17.2",
+    "@eyepop.ai/eyepop": "3.17.3",
+    "@eyepop.ai/eyepop-render-2d": "3.17.3",
     "@types/react-native-canvas": "^0.1.14",
     "buffer": "^6.0.3",
     "react": "^19.2.0",


### PR DESCRIPTION
## Summary
- Bump all SDK workspace package versions to 3.17.3.
- Keep exact internal workspace dependency pins aligned for the npm publish workflow.

## Verification
- `PATH=/opt/homebrew/opt/node@24/bin:$PATH npm install`
- `PATH=/opt/homebrew/opt/node@24/bin:$PATH npm run build -ws`