### PR TITLE
docs(render-2d): fix showTrackId, document renderClasses/renderKeypoints

### DIFF
--- a/src/eyepop-render-2d/README.md
+++ b/src/eyepop-render-2d/README.md
@@ -141,7 +141,7 @@ Most prebuild render classes provide a reasonable defaults, as shown below.
 Render2d.renderBox({
     showClass: true,
     showConfidence: false,
-    showTraceId: false,
+    showTrackId: false,
     showNestedClasses: false,
     target: '$..objects.*',
 })
@@ -180,6 +180,29 @@ Render2d.renderText({
 })
 ```
 
+#### Render Classification Labels
+
+Renders whole-image classification labels. Defaults shown:
+
+```typescript
+Render2d.renderClasses({
+    showConfidence: false,
+    labelSizePercentage: 0.05,
+    target: '$',
+})
+```
+
+#### Render Key Points
+
+Renders key points for any object that carries them. Defaults shown:
+
+```typescript
+Render2d.renderKeypoints({
+    showLabels: false,
+    target: '$..objects[?(@.keyPoints)]',
+})
+```
+
 #### Render Segmentation Masks
 
 ```typescript
@@ -196,13 +219,15 @@ Render2d.renderContour({
 })
 ```
 
-#### Blur an Object (TODO does black-put instead of blur)
+#### Blur an Object
 
 ```typescript
 Render2d.renderBlur({
     target: '$..objects[?(@.classLabel=="face")]',
 })
 ```
+
+Note: this currently paints a solid fill over the object rather than applying a true blur.
 
 #### Render a Trail of a traced object over time
 


### PR DESCRIPTION
Doc-only fixes to `src/eyepop-render-2d/README.md`, found while auditing the public EyePop docs against SDK source.

### 1. `showTraceId` → `showTrackId` (functional bug for readers)
The documented `renderBox` options list `showTraceId`, but the real option is `showTrackId` (`render-box.ts:17`, destructured at `:33`), matching `PredictedObject.trackId`. Anyone copying the documented snippet gets a silently-ignored key and no track IDs rendered.

### 2. `renderClasses` and `renderKeypoints` were undocumented
Both are exported from the `Render2d` namespace (`index.ts:31` and `:43`) but appear nowhere in the README. Added with their real constructor defaults:
- `renderClasses` — `showConfidence: false`, `labelSizePercentage: 0.05`, `target: '$'` (`render-classes.ts:30`)
- `renderKeypoints` — `showLabels: false`, `target: '$..objects[?(@.keyPoints)]'` (`render-keypoints.ts:15`)

### 3. TODO in a published heading
`#### Blur an Object (TODO does black-put instead of blur)` rendered the TODO into the public heading. Moved to a note below the snippet so the caveat survives without shipping a TODO — happy to drop the note entirely if the behavior is being fixed.

### Deliberately not changed
- `target: '$..objects.*'` on `renderBox` is **correct** (`render-box.ts:33`) — I checked, since `render.ts` also exports a different `DEFAULT_TARGET`.
- `showText` / `boxType` (`render-box.ts:15,18`) are real but undocumented. Left out to keep this reviewable; `boxType` needs the `BoxType` enum documented alongside it. Happy to add in a follow-up.

Context: the public docs at docs.eyepop.ai now link here as the canonical render-2d reference instead of maintaining a fork, so errors here reach customers directly.