### PR TITLE
[Node SDK]: Add standard check task and safe examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@ Official Node.js / TypeScript SDK for EyePop.ai's inference API — connect to w
 images/videos through vision pipelines ("Pops"). npm-workspaces monorepo (`src/eyepop`, `src/eyepop-render-2d`, `src/react-native-eyepop`).
 
 ## Commands
-npm workspaces (not pnpm/yarn/go-task). No single check task. Unit tests: `npm test` (jest, fully mocked).
-Before done, mirror CI (`.github/workflows/ci.yml`, Node 22): build `@eyepop.ai/eyepop` + `eyepop-render-2d`,
-`typecheck` `react-native-eyepop`, then `npx jest --runInBand`.
+Use npm workspaces (not pnpm/yarn). Install dependencies with `npm install`. Before done, run
+`task check`, which mirrors `.github/workflows/ci.yml`: build `@eyepop.ai/eyepop` and
+`eyepop-render-2d`, typecheck `react-native-eyepop`, then run Jest in-band.
 
 ## Gotchas
 - Dual node+browser codebase: `build` = `tsup` (CJS+ESM+dts) then `webpack` browser bundle; the `browser` field
@@ -18,6 +18,6 @@ Before done, mirror CI (`.github/workflows/ci.yml`, Node 22): build `@eyepop.ai/
   from `.env.example`. Its default abilities must stay account-portable; no private fixtures.
 - Publish is GitHub-Release-triggered and idempotent (skips any `name@version` already on npm). All three
   workspaces share one version with exact inter-pins — bump them in lockstep; `react-native-eyepop` has its own `release-it` path.
-- Version pins disagree (`engines` ≥18, READMEs say 20, `ci.yml` uses 22, `npm-publish.yml` uses 24) and
-  `lefthook.yml` ships entirely commented out — **no hooks are configured**, so nothing auto-runs lint/tests
+- The supported runtime floor is Node.js 18. CI validates Node.js 22 and the publish workflow uses Node.js 24.
+- `lefthook.yml` ships entirely commented out — **no hooks are configured**, so nothing auto-runs lint/tests
   locally even if a lefthook shim is installed in `.git/hooks`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The EyePop.ai Node SDK lets Node.js applications process images and videos with 
 npm install @eyepop.ai/eyepop
 ```
 
-The SDK is tested with Node 20 LTS and newer.
+Requires Node.js 18 or newer. CI validates Node.js 22.
 
 ## Configure
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,0 +1,20 @@
+version: "3"
+
+tasks:
+  check:
+    desc: Run the CI-equivalent build, typecheck, and unit-test gate
+    cmds:
+      - npm --workspace @eyepop.ai/eyepop run build
+      - npm --workspace @eyepop.ai/eyepop-render-2d run build
+      - npm --workspace @eyepop.ai/react-native-eyepop run typecheck
+      - npx jest --runInBand --testPathIgnorePatterns="<rootDir>/.worktrees"
+
+  test:
+    desc: Run unit tests
+    cmds:
+      - npm test
+
+  fmt:
+    desc: Format JavaScript, TypeScript, JSON, and Markdown
+    cmds:
+      - npm run format

--- a/examples/README.md
+++ b/examples/README.md
@@ -73,4 +73,4 @@ open http://localhost:8000/examples/web/static/multi_image_group.html
 
 (select two or more image files, then click Process Group to send them as a single image-group inference)
 
-If OAuth2 login isn't set up for your browser session, create an untracked `examples/web/static/env.js` defining `const apiKey = '<your api key>'` to authenticate with an API key instead (same fallback used by `dataset.html`/`modeltest.html`).
+Browser examples require OAuth2 login or a session created by a trusted backend. Never place an EyePop API key in `env.js` or any other browser-delivered file.

--- a/src/eyepop/README.md
+++ b/src/eyepop/README.md
@@ -6,7 +6,7 @@ The EyePop.ai Node SDK provides JavaScript and TypeScript access to EyePop worke
 
 ### Node
 
-The SDK is tested with Node 20 LTS and newer.
+Requires Node.js 18 or newer. CI validates Node.js 22.
 
 ```shell
 npm install --save @eyepop.ai/eyepop


### PR DESCRIPTION
## Summary
- add a Taskfile check gate matching CI
- align documented Node support with package metadata and CI
- remove the browser API-key fallback

## Validation
- npm install
- task check